### PR TITLE
Activity

### DIFF
--- a/src/org/rmj/auto/clients/base/Activity.java
+++ b/src/org/rmj/auto/clients/base/Activity.java
@@ -326,7 +326,7 @@ public class Activity {
                 lsSQL = MiscUtil.rowset2SQL(poMaster, 
                                             MASTER_TABLE, 
                                             "sDeptName»sCompnyNm»sProvName»sBranchNm",                                            
-                                            "sTransNox = " + SQLUtil.toSQL(lsTransNox));
+                                            "sActvtyID = " + SQLUtil.toSQL(lsTransNox));
                 if (poGRider.executeQuery(lsSQL, MASTER_TABLE, psBranchCd, "") <= 0){
                     psMessage = poGRider.getErrMsg();
                     if (!pbWithParent) poGRider.rollbackTrans();
@@ -380,6 +380,8 @@ public class Activity {
                             poTown.updateObject("sTransNox", lsTransNox);                                           
                             poTown.updateRow();
 
+                            
+                            
                             lsSQL = MiscUtil.rowset2SQL(poTown, "activity_town","sTownName");
                             //TODO what is substring(0,4)
                             if (poGRider.executeQuery(lsSQL, "activity_town", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
@@ -1054,6 +1056,7 @@ public class Activity {
                 
         return true;               
     }
+    
     /**
         * Loads town data based on the provided value.
         *
@@ -1093,14 +1096,22 @@ public class Activity {
         return true;            
     }
     
-//    public boolean addTown(String fsTownName) throws SQLException{
-//        String fsTown = poMaster.getString("sTownxxxx");
-//        if (fsTown.isEmpty()){
-//            
-//        }
-//        
-//        return true;
-//    }
+    public boolean removeTown(int fnRow){
+        try {
+            if (getTownCount()== 0) {
+                psMessage = "No Activity Town to delete.";
+                return false;
+            }
+            poTown.absolute(fnRow);
+            poTown.deleteRow();
+            //poTown.
+            return true;
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+    }
+    
     private String getSQ_Province(){
         return  " SELECT " +                    
                     " sProvIDxx " + 
@@ -1153,6 +1164,54 @@ public class Activity {
         return true;        
     }
     
+//    public String getSQ_Branch(){
+//        return " SELECT " +
+//                    " a.sBranchCd " +
+//                    ", a.sBranchNm " +
+//                " FROM branch a ,branch_others b " +                
+//                " WHERE a.sBranchCd = b.sBranchCd " +
+//                " AND a.cRecdStat = '1' " +
+//                " AND b.cDivision = " + poGRider.get;
+//    }
+    
+    
+//    public boolean searchBranch() throws SQLException{
+//        String lsSQL = getSQ_Branch();       
+//                
+//        ResultSet loRS;
+//        if (!pbWithUI) {   
+//            lsSQL += " LIMIT 1";
+//            loRS = poGRider.executeQuery(lsSQL);
+//            System.out.println(lsSQL);
+//            if (loRS.next()){
+//                setMaster("sProvIDxx", loRS.getString("sProvIDxx"));
+//                setMaster("sProvName", loRS.getString("sProvName"));               
+//            } else {
+//                psMessage = "No record found.";
+//                return false;
+//            }
+//        } else {
+//            loRS = poGRider.executeQuery(lsSQL);
+//            System.out.println(lsSQL);
+//            JSONObject loJSON = showFXDialog.jsonSearch(poGRider, 
+//                                                        lsSQL, 
+//                                                        "", 
+//                                                        "Province", 
+//                                                        "sProvName",
+//                                                        "sProvName",
+//                                                        0);
+//            
+//            if (loJSON == null){
+//                psMessage = "No record found/selected.";
+//                return false;
+//            } else {
+//                setMaster("sProvIDxx", (String) loJSON.get("sProvIDxx"));
+//                setMaster("sProvName", (String) loJSON.get("sProvName"));                
+//            }
+//        }        
+//        return true;        
+//        
+//    }
     
     public void displayMasFields() throws SQLException{
         if (pnEditMode != EditMode.ADDNEW && pnEditMode != EditMode.UPDATE) return;

--- a/src/org/rmj/auto/clients/base/Activity.java
+++ b/src/org/rmj/auto/clients/base/Activity.java
@@ -7,13 +7,16 @@ package org.rmj.auto.clients.base;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Date;
 import javax.sql.rowset.CachedRowSet;
 import javax.sql.rowset.RowSetFactory;
 import javax.sql.rowset.RowSetProvider;
+import org.json.simple.JSONObject;
 import org.rmj.appdriver.GRider;
 import org.rmj.appdriver.MiscUtil;
 import org.rmj.appdriver.SQLUtil;
+import org.rmj.appdriver.agentfx.ui.showFXDialog;
 import org.rmj.appdriver.callback.MasterCallback;
 import org.rmj.appdriver.constants.EditMode;
 import org.rmj.appdriver.constants.RecordStatus;
@@ -40,9 +43,11 @@ public class Activity {
     private boolean pbWithUI;
     private String psMessage;
     
-    private CachedRowSet poMaster;
-    private CachedRowSet poDepartment;
-    private CachedRowSet poActMember;
+    public CachedRowSet poMaster;
+    public CachedRowSet poDepartment;
+    public CachedRowSet poActMember;
+    public CachedRowSet poEmployees;
+    public CachedRowSet poActVehicle;
     
     public Activity(GRider foGRider, String fsBranchCd, boolean fbWithParent){            
         
@@ -72,15 +77,34 @@ public class Activity {
         poMaster.first();
         
         switch (fnIndex){  
-            case 1 ://sTransNox
-           
+            case 1 :        //sActvtyID  
+            case 2 :        //sActTitle 
+            case 3 :        //sActDescx 
+            case 4 :        //sActTypID 
+            case 5 :        //sActSrcex            
+            case 8 :        //sAddressx 
+            case 9 :        //sTownIDxx 
+            case 10:        //sLocation 
+            case 11:        //sCompnynx           
+            case 15:        //sEmployID 
+            case 16:        //sDeptIDxx
+            case 17:        //sLogRemrk 
+            case 18:        //sRemarksx             
+            case 20:        //sEntryByx            
+            case 22:        //sApproved           
+            case 24:        //sModified            
+            case 26:        //sDeptName
+            case 27:        //sCompnyNm
+            case 28:        //sBranchNm                       
                 poMaster.updateObject(fnIndex, (String) foValue);
                 poMaster.updateRow();
                 
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
                 break;
-            case 5 ://cIsVhclNw            
-                         
+            case 12:        //nPropBdgt 
+            case 13:        //nRcvdBdgt 
+            case 14:        //nTrgtClnt           
+            case 19:        //cTranStat           
                 if (foValue instanceof Integer)
                     poMaster.updateInt(fnIndex, (int) foValue);
                 else 
@@ -88,9 +112,12 @@ public class Activity {
                 
                 poMaster.updateRow();
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));  
-                break;  
-            case 3 ://dTransact
-           
+                break;              
+            case 6 :        //dDateFrom 
+            case 7 :        //dDateThru
+            case 21:        //dEntryDte 
+            case 23:        //dApproved 
+            case 25:        //dModified 
                 if (foValue instanceof Date){
                     poMaster.updateObject(fnIndex, foValue);
                 } else {
@@ -121,11 +148,73 @@ public class Activity {
         return poMaster.getRow();
     }
     
+    /**
+
+    Initializes the master data for adding a new entry.
+
+    @return {@code true} if the master data is successfully initialized, {@code false} otherwise
+    */
     public boolean NewRecord(){
+        if (poGRider == null){
+            psMessage = "Application driver is not set.";
+            return false;
+        }
+        
+        if (psBranchCd.isEmpty()) psBranchCd = poGRider.getBranchCode();
+        try {       
+            String lsSQL = getSQ_Master() + " WHERE 0=1";
+            //String lsSQL = MiscUtil.addCondition(getSQ_Master(), "0=1"); 
+            System.out.println(lsSQL);
+            ResultSet loRS = poGRider.executeQuery(lsSQL);
+            RowSetFactory factory = RowSetProvider.newFactory();
+            //----------------------------------Inquiry Master------------------
+            
+            poMaster = factory.createCachedRowSet();
+            poMaster.populate(loRS);
+            MiscUtil.close(loRS);
+            
+            poMaster.last();
+            poMaster.moveToInsertRow();
+            
+            MiscUtil.initRowSet(poMaster);       
+            //poMaster.updateString("cRecdStat", RecordStatus.ACTIVE);            
+            poMaster.updateString("cTranStat", "0");
+            poMaster.updateObject("dDateFrom", poGRider.getServerDate());    
+            poMaster.updateObject("dDateThru", poGRider.getServerDate());                       
+
+            poMaster.insertRow();
+            poMaster.moveToCurrentRow();     
+            //---------------------------------Activity Member------------------
+            lsSQL = getSQ_ActMember()+ " WHERE 0=1";
+            //String lsSQL = MiscUtil.addCondition(getSQ_Master(), "0=1"); 
+            //System.out.println(lsSQL);
+            loRS = poGRider.executeQuery(lsSQL);
+            
+            poActMember = factory.createCachedRowSet();
+            poActMember.populate(loRS);
+            MiscUtil.close(loRS);
+            
+            poActMember.last();
+            poActMember.moveToInsertRow();
+            
+            MiscUtil.initRowSet(poActMember);       
+            //poMaster.updateString("cRecdStat", RecordStatus.ACTIVE);            
+//            poActMember.updateString("cTranStat", "0");
+//            poActMember.updateObject("dDateFrom", poGRider.getServerDate());    
+//            poActMember.updateObject("dDateThru", poGRider.getServerDate());                       
+
+            poActMember.insertRow();
+            poActMember.moveToCurrentRow();         
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+        pnEditMode = EditMode.ADDNEW;
         return true;
     }
     
     public boolean UpdateRecord(){
+        pnEditMode = EditMode.UPDATE;        
         return true;
     }
     
@@ -133,16 +222,155 @@ public class Activity {
         return true;
     }
     
-    public boolean SearchRecord(){
-        return true;
+    /**
+
+    Searches for a record based on the specified value and search criteria.
+
+    @param fsValue the value used for searching
+
+    @param fbByCode determines if the search is performed by activity code or activity title
+
+    @return {@code true} if a matching record is found and successfully opened, {@code false} otherwise
+
+    @throws SQLException if an SQL exception occurs during the search
+    */
+    public boolean SearchRecord(String fsValue,boolean fbByCode) throws SQLException{
+        if (poGRider == null){
+            psMessage = "Application driver is not set.";
+            return false;
+        }
+        
+        psMessage = "";    
+        
+        String lsSQL = getSQ_Master();
+        
+        if (pbWithUI){
+            JSONObject loJSON = showFXDialog.jsonSearch(
+                                poGRider, 
+                                lsSQL, 
+                                fsValue, 
+                                "Activity ID»Activity Title»", 
+                                "sActvtyID»sActTitle", 
+                                "a.sActvtyID»a.sActTitle", 
+                                fbByCode ? 0 : 1 );
+            
+            if (loJSON != null) 
+                return OpenRecord((String) loJSON.get("sActvtyID"));
+            else {
+                psMessage = "No record selected.";
+                return false;
+            }
+        }
+        
+        if (fbByCode)
+            lsSQL = MiscUtil.addCondition(lsSQL, "a.sActvtyID = " + SQLUtil.toSQL(fsValue));   
+        else {
+            if (!fsValue.isEmpty()) {
+                lsSQL = MiscUtil.addCondition(lsSQL, "sActTitle LIKE " + SQLUtil.toSQL("%" + fsValue + "%"));                 
+            }
+        }
+        
+        ResultSet loRS = poGRider.executeQuery(lsSQL);
+        
+        if (!loRS.next()){
+            MiscUtil.close(loRS);
+            psMessage = "No record found for the given criteria.";
+            return false;
+        }
+        
+        lsSQL = loRS.getString("sActvtyID");
+        MiscUtil.close(loRS);
+        
+        
+        return OpenRecord(lsSQL);
     }
     
-    public boolean OpenRecord(){
-        return true;
+    /**
+
+    Opens a record with the specified value.
+
+    @param fsValue the value used to open the record
+
+    @return {@code true} if the record is successfully opened, {@code false} otherwise
+    */
+    public boolean OpenRecord(String fsValue){
+        pnEditMode = EditMode.UNKNOWN;
+        
+        if (poGRider == null){
+            psMessage = "Application driver is not set.";
+            return false;
+        }
+        
+        try {
+            String lsSQL;
+            ResultSet loRS;
+            RowSetFactory factory = RowSetProvider.newFactory();
+
+            //open master            
+            //lsSQL = MiscUtil.addCondition(getSQ_Master(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));
+            lsSQL = getSQ_Master() + " WHERE a.sTransNox = " + SQLUtil.toSQL(fsValue);
+            loRS = poGRider.executeQuery(lsSQL);
+            poMaster = factory.createCachedRowSet();
+            poMaster.populate(loRS);
+            MiscUtil.close(loRS);
+
+            //open Act Member
+            lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));
+            loRS = poGRider.executeQuery(lsSQL);
+            poActMember = factory.createCachedRowSet();
+            poActMember.populate(loRS);
+            MiscUtil.close(loRS);
+
+            //open Act Vehicle
+            lsSQL = MiscUtil.addCondition(getSQ_ActVehicle(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));
+            loRS = poGRider.executeQuery(lsSQL);
+            poActVehicle = factory.createCachedRowSet();
+            poActVehicle.populate(loRS);
+            MiscUtil.close(loRS);
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+        
+        pnEditMode = EditMode.READY;
+        return true;        
     }
     
     private String getSQ_Master(){
-        return "" ;       
+        return  " SELECT " +
+                    " a.sActvtyID  " + //1
+                    " ,a.sActTitle " + //2
+                    " ,a.sActDescx " + //3
+                    " ,a.sActTypID " + //4
+                    " ,a.sActSrcex " + //5
+                    " ,a.dDateFrom " + //6
+                    " ,a.dDateThru " + //7
+                    " ,a.sAddressx " + //8
+                    " ,a.sTownIDxx " + //9
+                    " ,a.sLocation " + //10
+                    " ,a.sCompnynx " + //11
+                    " ,a.nPropBdgt " + //12
+                    " ,a.nRcvdBdgt " + //13
+                    " ,a.nTrgtClnt " + //14
+                    " ,a.sEmployID " + //15
+                    " ,a.sDeptIDxx " + //16
+                    " ,a.sLogRemrk " + //17
+                    " ,a.sRemarksx " + //18 
+                    " ,a.cTranStat " + //19
+                    " ,a.sEntryByx " + //20
+                    " ,a.dEntryDte " + //21
+                    " ,a.sApproved " + //22
+                    " ,a.dApproved " + //23
+                    " ,a.sModified " + //24
+                    " ,a.dModified " + //25
+                    " ,IFNULL(b.sDeptName , '') sDeptName " + //26
+                    " ,IFNULL(d.sCompnyNm , '') sCompnyNm " + //27
+                    " ,IFNULL(e.sBranchNm , '') sBranchNm " + //28
+                " FROM ggc_anyautodbf.activity_master a " +
+                " LEFT JOIN ggc_isysdbf.department b ON b.sDeptIDxx = a.sDeptIDxx " +
+                " LEFT JOIN ggc_isysdbf.Employee_Master001 c ON c.sEmployID = a.sEmployID " +
+                " LEFT JOIN ggc_isysdbf.client_master d on d.sClientID = a.sEmployID " +
+                " LEFT JOIN ggc_anyautodbf.branch e on e.sBranchCd = a.sLocation "  ;       
     }
     
     private String getSQ_Department(){
@@ -151,7 +379,60 @@ public class Activity {
                     " , sDeptName " +
                 "FROM ggc_isysdbf.department ";                
     }
-           
+    
+    /**
+
+    Searches for a department based on the specified value.
+
+    @param fsValue the value used for searching the department
+
+    @return {@code true} if the department is found, {@code false} otherwise
+
+    @throws SQLException if an SQL exception occurs
+    */
+    public boolean searchDepartment(String fsValue) throws SQLException{
+        String lsSQL = MiscUtil.addCondition(getSQ_Department(), " sDeptName LIKE " + SQLUtil.toSQL(fsValue + "%"));            
+                
+        ResultSet loRS;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            System.out.println(lsSQL);
+            if (loRS.next()){
+                setMaster("sDeptIDxx", loRS.getString("sDeptIDxx"));
+                setMaster("sDeptName", loRS.getString("sDeptName"));               
+            } else {
+                psMessage = "No record found.";
+                return false;
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            System.out.println(lsSQL);
+            JSONObject loJSON = showFXDialog.jsonSearch(poGRider, 
+                                                        lsSQL, 
+                                                        fsValue, 
+                                                        "Department Name", 
+                                                        "sDeptName",
+                                                        "sDeptName",
+                                                        0);
+            
+            if (loJSON == null){
+                psMessage = "No record found/selected.";
+                return false;
+            } else {
+                setMaster("sDeptIDxx", (String) loJSON.get("sDeptIDxx"));
+                setMaster("sDeptName", (String) loJSON.get("sDeptName"));                
+            }
+        }        
+        return true;
+    }
+    
+    /**
+
+    Loads the department data.
+
+    @return {@code true} if the department data is successfully loaded, {@code false} otherwise
+    */
     public boolean loadDepartment(){
         try {
             if (poGRider == null){
@@ -202,6 +483,28 @@ public class Activity {
         }      
     }
     
+    //Query for searching vehicle
+    private String getSQ_Vehicle(){
+        return  "SELECT " + 
+                    " sVhclIDxx " + //1
+                    ", sDescript" + //2                   
+                " FROM Vehicle_master " ;                    
+    }
+    
+    private String getSQ_ActVehicle(){
+        return  "SELECT " + 
+                    " a.sTransNox" + //1
+                    ", a.nEntryNox" + //2
+                    ", a.sSerialID" + //3                   
+                    ", IFNULL(c.sDescript, '') sDescript" + //6
+                " FROM activity_vehicle a" +
+                    " LEFT JOIN vehicle_serial b on b.sSerialID = a.sSerialID" +
+                    " LEFT JOIN vehicle_master c ON b.sVhclIDxx = c.sVhclIDxx";
+    }
+    
+    public boolean loadActVehicle(){
+        return true;
+    }
     
     private String getSQ_Employee(){
         return " SELECT " +                                                           
@@ -211,9 +514,11 @@ public class Activity {
                     " ,a.sDeptIDxx " +                                                    
                 " FROM ggc_isysdbf.employee_master001 a	" +                            
                 " LEFT JOIN ggc_isysdbf.department b ON  b.sDeptIDxx = a.sDeptIDxx " + 
-                " LEFT JOIN ggc_isysdbf.client_master c on c.sClientID = a.sEmployID " 
-;
+                " LEFT JOIN ggc_isysdbf.client_master c on c.sClientID = a.sEmployID " +
+                " WHERE a.cRecdStat = '1' " +
+                " AND ISNULL(a.dFiredxxx) ";
     }
+    
     private String getSQ_ActMember(){
         return " SELECT " +
                     " a.sTransNox  " +
@@ -229,7 +534,65 @@ public class Activity {
                 " LEFT JOIN ggc_isysdbf.client_master c ON c.sClientID = a.sEmployID " +
                 " LEFT JOIN ggc_isysdbf.department d on d.sDeptIDxx = b.sDeptIDxx";
     }
+    /**
+
+    Searches for an employee based on the specified value.
+
+    @param fsValue the value used for searching the employee
+
+    @return {@code true} if the employee is found, {@code false} otherwise
+
+    @throws SQLException if an SQL exception occurs
+    */
+    public boolean searchEmployee(String fsValue) throws SQLException {
+        String lsSQL = MiscUtil.addCondition(getSQ_Employee(), " sCompnyNm LIKE " + SQLUtil.toSQL(fsValue + "%"));            
+                
+        ResultSet loRS;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            System.out.println(lsSQL);
+            if (loRS.next()){
+                setMaster("sCompnyNm", loRS.getString("sCompnyNm"));
+                setMaster("sEmployID", loRS.getString("sEmployID"));               
+            } else {
+                psMessage = "No record found.";
+                return false;
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            System.out.println(lsSQL);
+            JSONObject loJSON = showFXDialog.jsonSearch(poGRider, 
+                                                        lsSQL, 
+                                                        fsValue, 
+                                                        "Employee Name,Department Name", 
+                                                        "sCompnyNm»sDeptName",
+                                                        "sCompnyNm»sDeptName",
+                                                        0);
+            
+            if (loJSON == null){
+                psMessage = "No record found/selected.";
+                return false;
+            } else {
+                setMaster("sCompnyNm", (String) loJSON.get("sCompnyNm"));
+                setMaster("sEmployID", (String) loJSON.get("sEmployID"));                
+            }
+        }        
+        return true;
+    }
     
+    /**
+
+    Loads employee data based on the specified value and load mode.
+
+    @param fsValue the value used for loading employee data
+
+    @param fbLoadEmp the load mode indicating whether to load employees or activity members
+
+    @return {@code true} if the employee data is successfully loaded, {@code false} otherwise
+
+    @throws SQLException if an SQL exception occurs
+    */
     public boolean loadEmployee(String fsValue, boolean fbLoadEmp) throws SQLException{
         
         try {
@@ -243,17 +606,23 @@ public class Activity {
             
             if (fbLoadEmp){
                 //For Searching when adding activity member when department is clicked
-                lsSQL = MiscUtil.addCondition(getSQ_Employee(), "b.sDeptIDxx = " + SQLUtil.toSQL(fsValue));                
+                lsSQL = MiscUtil.addCondition(getSQ_Employee(), "b.sDeptIDxx = " + SQLUtil.toSQL(fsValue));                     
+                loRS = poGRider.executeQuery(lsSQL);            
+            
+                poEmployees = factory.createCachedRowSet();
+                poEmployees.populate(loRS);
+                MiscUtil.close(loRS);
             }else{
                 
-                lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));                
+                lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "a.sTransNox = " + SQLUtil.toSQL(fsValue)); 
+                loRS = poGRider.executeQuery(lsSQL);            
+            
+                poActMember = factory.createCachedRowSet();
+                poActMember.populate(loRS);
+                MiscUtil.close(loRS);
             }  
                                     
-            loRS = poGRider.executeQuery(lsSQL);            
             
-            poActMember = factory.createCachedRowSet();
-            poActMember.populate(loRS);
-            MiscUtil.close(loRS);
                         
         } catch (SQLException e) {
             psMessage = e.getMessage();
@@ -264,18 +633,25 @@ public class Activity {
         return true;                                                
     }
     
-    public boolean addMember(String fsEmployID, String fsEmpName, String fsDept) throws SQLException{
-     //   int lnCtr;
-    //    int lnRow = getItemCount();
-        
-        //validate if incentive is already added
-//        for (lnCtr = 1; lnCtr <= lnRow; lnCtr++){
-//            if (fsCode.equals((String) getAddress(lnCtr, "sAddrssID"))) return true;
-//        }
+    /**
+
+    Adds a member to the system.
+
+    @param fsEmployID the employee ID of the member
+
+    @param fsEmpName the name of the member
+
+    @param fsDept the department of the member
+
+    @return {@code true} if the member is successfully added, {@code false} otherwise
+
+    @throws SQLException if an SQL exception occurs
+    */
+    public boolean addMember(String fsEmployID, String fsEmpName, String fsDept) throws SQLException{   
         if (poActMember == null){
             String lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "0=1");
             ResultSet loRS = poGRider.executeQuery(lsSQL);
-            
+            System.out.println(lsSQL);
             RowSetFactory factory = RowSetProvider.newFactory();
             poActMember = factory.createCachedRowSet();
             poActMember.populate(loRS);
@@ -289,27 +665,30 @@ public class Activity {
           
         poActMember.updateString("sEmployID", fsEmployID);
         poActMember.updateString("sCompnyNm", fsEmpName);
-        poActMember.updateObject("nEntryNox", getActMemberCount());        
+//        poActMember.updateObject("nEntryNox", getActMemberCount());        
         poActMember.updateString("sDeptName", fsDept);        
         poActMember.insertRow();
         poActMember.moveToCurrentRow();
                 
-        return true;
+        return true;               
     }
     
     //------------------------------Activity Member-----------------------------
     //Activity Member Setter
     public void setActMember(int fnRow, int fnIndex, Object foValue) throws SQLException{        
-        poActMember.absolute(fnRow); 
-        
+        poActMember.absolute(fnRow);         
         switch (fnIndex){  
-            case 1 ://sTransNox                                             
+            case 1 ://sTransNox  
+            case 3 ://sEmployID
+            case 7 ://sCompnyNm
+            case 8 ://sDeptName
+            //case 4 ://cOriginal               
                 poActMember.updateObject(fnIndex, (String) foValue);
                 poActMember.updateRow();
                 
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
                 break;
-            case 2 ://nPriority                            
+            case 2 ://nEntryNox                            
                 if (foValue instanceof Integer)
                     poActMember.updateInt(fnIndex, (int) foValue);
                 else 
@@ -361,7 +740,7 @@ public class Activity {
 
     @return {@code true} if the activity member was successfully removed, {@code false} otherwise.
     */
-    public boolean removeActMember(int fnRow){
+    public boolean removeMember(int fnRow){
         try {
             if (getActMemberCount() == 0) {
                 psMessage = "No Activity Member delete.";
@@ -375,5 +754,57 @@ public class Activity {
             return false;
         }
     }
+    
+    public void displayMasFields() throws SQLException{
+        if (pnEditMode != EditMode.ADDNEW && pnEditMode != EditMode.UPDATE) return;
+        
+        int lnRow = poMaster.getMetaData().getColumnCount();
+        
+        System.out.println("----------------------------------------");
+        System.out.println("MASTER TABLE INFO");
+        System.out.println("----------------------------------------");
+        System.out.println("Total number of columns: " + lnRow);
+        System.out.println("----------------------------------------");
+        
+        for (int lnCtr = 1; lnCtr <= lnRow; lnCtr++){
+            System.out.println("Column index: " + (lnCtr) + " --> Label: " + poMaster.getMetaData().getColumnLabel(lnCtr));
+            System.out.println("Column type: " + (lnCtr) + " --> " + poMaster.getMetaData().getColumnType(lnCtr));
+            if (poMaster.getMetaData().getColumnType(lnCtr) == Types.CHAR ||
+                poMaster.getMetaData().getColumnType(lnCtr) == Types.VARCHAR){
+                
+                System.out.println("Column index: " + (lnCtr) + " --> Size: " + poMaster.getMetaData().getColumnDisplaySize(lnCtr));
+            }
+        }
+        
+        System.out.println("----------------------------------------");
+        System.out.println("END: MASTER TABLE INFO");
+        System.out.println("----------------------------------------");
+    } 
+    
+    public void displayMemberFields() throws SQLException{
+        if (pnEditMode != EditMode.ADDNEW && pnEditMode != EditMode.UPDATE) return;
+        
+        int lnRow = poActMember.getMetaData().getColumnCount();
+        
+        System.out.println("----------------------------------------");
+        System.out.println("ACTIVITY MEMBER TABLE INFO");
+        System.out.println("----------------------------------------");
+        System.out.println("Total number of columns: " + lnRow);
+        System.out.println("----------------------------------------");
+        
+        for (int lnCtr = 1; lnCtr <= lnRow; lnCtr++){
+            System.out.println("Column index: " + (lnCtr) + " --> Label: " + poActMember.getMetaData().getColumnLabel(lnCtr));
+            System.out.println("Column type: " + (lnCtr) + " --> " + poActMember.getMetaData().getColumnType(lnCtr));
+            if (poActMember.getMetaData().getColumnType(lnCtr) == Types.CHAR ||
+                poActMember.getMetaData().getColumnType(lnCtr) == Types.VARCHAR){
+                
+                System.out.println("Column index: " + (lnCtr) + " --> Size: " + poActMember.getMetaData().getColumnDisplaySize(lnCtr));
+            }
+        }
+        
+        System.out.println("----------------------------------------");
+        System.out.println("END: ACTIVITY MEMBER TABLE INFO");
+        System.out.println("----------------------------------------");
+    } 
     
 }

--- a/src/org/rmj/auto/clients/base/Activity.java
+++ b/src/org/rmj/auto/clients/base/Activity.java
@@ -1,0 +1,379 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.rmj.auto.clients.base;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Date;
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetFactory;
+import javax.sql.rowset.RowSetProvider;
+import org.rmj.appdriver.GRider;
+import org.rmj.appdriver.MiscUtil;
+import org.rmj.appdriver.SQLUtil;
+import org.rmj.appdriver.callback.MasterCallback;
+import org.rmj.appdriver.constants.EditMode;
+import org.rmj.appdriver.constants.RecordStatus;
+
+/**
+ *
+ * @author jahn 05-18-2023
+ */
+public class Activity {
+    private final String MASTER_TABLE = "activity_master";
+    private final String DEFAULT_DATE = "1900-01-01";
+    
+    private final String SALES = "";
+    private final String SALES_ADMIN = "";
+    private final String MIS = "";
+    private final String MAIN_OFFICE = "M001»M0W1";
+    
+    private GRider poGRider;
+    private String psBranchCd;
+    private boolean pbWithParent;
+    private MasterCallback poCallback;
+    
+    private int pnEditMode;
+    private boolean pbWithUI;
+    private String psMessage;
+    
+    private CachedRowSet poMaster;
+    private CachedRowSet poDepartment;
+    private CachedRowSet poActMember;
+    
+    public Activity(GRider foGRider, String fsBranchCd, boolean fbWithParent){            
+        
+        poGRider = foGRider;
+        psBranchCd = fsBranchCd;
+        pbWithParent = fbWithParent;                       
+    }
+    
+    public int getEditMode(){
+        return pnEditMode;
+    }
+    
+    public String getMessage(){
+        return psMessage;
+    }
+    
+    public void setWithUI(boolean fbValue){
+        pbWithUI = fbValue;
+    }
+    
+    public void setCallback(MasterCallback foValue){
+        poCallback = foValue;
+    }
+    
+    //TODO add setMaster for inquiry
+    public void setMaster(int fnIndex, Object foValue) throws SQLException{        
+        poMaster.first();
+        
+        switch (fnIndex){  
+            case 1 ://sTransNox
+           
+                poMaster.updateObject(fnIndex, (String) foValue);
+                poMaster.updateRow();
+                
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
+                break;
+            case 5 ://cIsVhclNw            
+                         
+                if (foValue instanceof Integer)
+                    poMaster.updateInt(fnIndex, (int) foValue);
+                else 
+                    poMaster.updateInt(fnIndex, 0);
+                
+                poMaster.updateRow();
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));  
+                break;  
+            case 3 ://dTransact
+           
+                if (foValue instanceof Date){
+                    poMaster.updateObject(fnIndex, foValue);
+                } else {
+                    poMaster.updateObject(fnIndex, SQLUtil.toDate(DEFAULT_DATE, SQLUtil.FORMAT_SHORT_DATE));
+                }
+                poMaster.updateRow();                
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
+                break;      
+        }            
+    }   
+    
+    //Activity Master setter
+    public void setMaster(String fsIndex, Object foValue) throws SQLException{
+        setMaster(MiscUtil.getColumnIndex(poMaster, fsIndex), foValue);
+    }
+    //Activity Master getter
+    public Object getMaster(String fsIndex) throws SQLException{
+        return getMaster(MiscUtil.getColumnIndex(poMaster, fsIndex));
+    }
+    //Activity Master getter
+    public Object getMaster(int fnIndex) throws SQLException{
+        poMaster.first();
+        return poMaster.getObject(fnIndex);
+    }
+    
+    public int getItemCount() throws SQLException{
+        poMaster.last();
+        return poMaster.getRow();
+    }
+    
+    public boolean NewRecord(){
+        return true;
+    }
+    
+    public boolean UpdateRecord(){
+        return true;
+    }
+    
+    public boolean SaveRecord(){
+        return true;
+    }
+    
+    public boolean SearchRecord(){
+        return true;
+    }
+    
+    public boolean OpenRecord(){
+        return true;
+    }
+    
+    private String getSQ_Master(){
+        return "" ;       
+    }
+    
+    private String getSQ_Department(){
+        return "SELECT " + 
+                    "sDeptIDxx" +
+                    " , sDeptName " +
+                "FROM ggc_isysdbf.department ";                
+    }
+           
+    public boolean loadDepartment(){
+        try {
+            if (poGRider == null){
+                psMessage = "Application driver is not set.";
+                return false;
+            }
+            String lsSQL;
+            ResultSet loRS;
+            RowSetFactory factory = RowSetProvider.newFactory();
+            
+                            
+            lsSQL = MiscUtil.addCondition(getSQ_Department(), "cRecdStat = " + SQLUtil.toSQL("1"));                
+             
+                                    
+            loRS = poGRider.executeQuery(lsSQL);            
+            
+            poDepartment = factory.createCachedRowSet();
+            poDepartment.populate(loRS);
+            MiscUtil.close(loRS);
+                        
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+        
+        pnEditMode = EditMode.READY;
+        return true;               
+    }
+            
+    public Object getDepartment(int fnRow, int fnIndex) throws SQLException{
+        if (fnIndex == 0) return null;
+        
+        poDepartment.absolute(fnRow);
+        return poDepartment.getObject(fnIndex);
+    }
+    
+    public Object getDepartment(int fnRow, String fsIndex) throws SQLException{
+        if (getDeptCount()== 0 || fnRow > getDeptCount()) return null;
+        return getDepartment(fnRow, MiscUtil.getColumnIndex(poDepartment, fsIndex));
+    }
+    
+    public int getDeptCount() throws SQLException{
+        if (poDepartment != null){
+            poDepartment.last();
+            return poDepartment.getRow();
+        }else{
+            return 0;
+        }      
+    }
+    
+    
+    private String getSQ_Employee(){
+        return " SELECT " +                                                           
+                    " c.sCompnyNm  " +                                                    
+                    " ,a.sEmployID " +                                                    
+                    " ,b.sDeptName " +                                                    
+                    " ,a.sDeptIDxx " +                                                    
+                " FROM ggc_isysdbf.employee_master001 a	" +                            
+                " LEFT JOIN ggc_isysdbf.department b ON  b.sDeptIDxx = a.sDeptIDxx " + 
+                " LEFT JOIN ggc_isysdbf.client_master c on c.sClientID = a.sEmployID " 
+;
+    }
+    private String getSQ_ActMember(){
+        return " SELECT " +
+                    " a.sTransNox  " +
+                    " , a.nEntryNox " +
+                    " , a.sEmployID " +
+                    " , a.cOriginal " +
+                    " , a.sEntryByx " +
+                    " , a.dEntryDte " +
+                    " , IFNULL(c.sCompnyNm, '') sCompnyNm " +
+                    " , IFNULL(d.sDeptName, '') sDeptName " +
+                " FROM ggc_anyautodbf.activity_member a " +
+                " LEFT JOIN ggc_isysdbf.employee_master001 b ON b.sEmployID = a.sEmployID " +
+                " LEFT JOIN ggc_isysdbf.client_master c ON c.sClientID = a.sEmployID " +
+                " LEFT JOIN ggc_isysdbf.department d on d.sDeptIDxx = b.sDeptIDxx";
+    }
+    
+    public boolean loadEmployee(String fsValue, boolean fbLoadEmp) throws SQLException{
+        
+        try {
+            if (poGRider == null){
+                psMessage = "Application driver is not set.";
+                return false;
+            }
+            String lsSQL;
+            ResultSet loRS;
+            RowSetFactory factory = RowSetProvider.newFactory();
+            
+            if (fbLoadEmp){
+                //For Searching when adding activity member when department is clicked
+                lsSQL = MiscUtil.addCondition(getSQ_Employee(), "b.sDeptIDxx = " + SQLUtil.toSQL(fsValue));                
+            }else{
+                
+                lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));                
+            }  
+                                    
+            loRS = poGRider.executeQuery(lsSQL);            
+            
+            poActMember = factory.createCachedRowSet();
+            poActMember.populate(loRS);
+            MiscUtil.close(loRS);
+                        
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+        
+        pnEditMode = EditMode.READY;
+        return true;                                                
+    }
+    
+    public boolean addMember(String fsEmployID, String fsEmpName, String fsDept) throws SQLException{
+     //   int lnCtr;
+    //    int lnRow = getItemCount();
+        
+        //validate if incentive is already added
+//        for (lnCtr = 1; lnCtr <= lnRow; lnCtr++){
+//            if (fsCode.equals((String) getAddress(lnCtr, "sAddrssID"))) return true;
+//        }
+        if (poActMember == null){
+            String lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "0=1");
+            ResultSet loRS = poGRider.executeQuery(lsSQL);
+            
+            RowSetFactory factory = RowSetProvider.newFactory();
+            poActMember = factory.createCachedRowSet();
+            poActMember.populate(loRS);
+            MiscUtil.close(loRS);
+        }
+        
+        poActMember.last();
+        poActMember.moveToInsertRow();
+
+        MiscUtil.initRowSet(poActMember);  
+          
+        poActMember.updateString("sEmployID", fsEmployID);
+        poActMember.updateString("sCompnyNm", fsEmpName);
+        poActMember.updateObject("nEntryNox", getActMemberCount());        
+        poActMember.updateString("sDeptName", fsDept);        
+        poActMember.insertRow();
+        poActMember.moveToCurrentRow();
+                
+        return true;
+    }
+    
+    //------------------------------Activity Member-----------------------------
+    //Activity Member Setter
+    public void setActMember(int fnRow, int fnIndex, Object foValue) throws SQLException{        
+        poActMember.absolute(fnRow); 
+        
+        switch (fnIndex){  
+            case 1 ://sTransNox                                             
+                poActMember.updateObject(fnIndex, (String) foValue);
+                poActMember.updateRow();
+                
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
+                break;
+            case 2 ://nPriority                            
+                if (foValue instanceof Integer)
+                    poActMember.updateInt(fnIndex, (int) foValue);
+                else 
+                    poActMember.updateInt(fnIndex, 0);
+                
+                poActMember.updateRow();
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));  
+                break;             
+        }            
+    }   
+    
+    public void setActMember(int fnRow, String fsIndex, Object foValue) throws SQLException{
+        setActMember(fnRow,MiscUtil.getColumnIndex(poActMember, fsIndex), foValue);
+    }
+    //Activity Member GETTER    
+    public Object getActMember(int fnRow, int fnIndex) throws SQLException{
+        if (fnIndex == 0) return null;
+        
+        poActMember.absolute(fnRow);
+        return poActMember.getObject(fnIndex);
+    }
+    
+    //Activity Member GETTER
+    public Object getActMember(int fnRow, String fsIndex) throws SQLException{
+        return getActMember(fnRow, MiscUtil.getColumnIndex(poActMember, fsIndex));
+    }        
+    
+    //get rowcount of Activity Member
+    public int getActMemberCount() throws SQLException{
+        try {
+            if (poActMember != null){
+                poActMember.last();
+                return poActMember.getRow();
+            }else{
+                return 0;
+            }  
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return 0;
+        }
+    }   
+    
+    //Remove activity member
+    /**
+
+    Removes an activity member at the specified row index.
+
+    @param fnRow The row index of the activity member to be removed.
+
+    @return {@code true} if the activity member was successfully removed, {@code false} otherwise.
+    */
+    public boolean removeActMember(int fnRow){
+        try {
+            if (getActMemberCount() == 0) {
+                psMessage = "No Activity Member delete.";
+                return false;
+            }
+            poActMember.absolute(fnRow);
+            poActMember.deleteRow();
+            return true;
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+    }
+    
+}

--- a/src/org/rmj/auto/clients/base/Activity.java
+++ b/src/org/rmj/auto/clients/base/Activity.java
@@ -77,38 +77,36 @@ public class Activity {
     public void setMaster(int fnIndex, Object foValue) throws SQLException{        
         poMaster.first();
         
+        
         switch (fnIndex){  
             case 1 :        //sActvtyID  
             case 2 :        //sActTitle 
             case 3 :        //sActDescx 
             case 4 :        //sActTypID 
-            case 5 :        //sActSrcex            
-            case 8 :        //sAddressx 
-            case 9 :        //sTownIDxx 
-            case 10:        //sLocation 
-            case 11:        //sCompnynx           
-            case 15:        //sEmployID 
-            case 16:        //sDeptIDxx
-            case 17:        //sLogRemrk 
-            case 18:        //sRemarksx             
-            case 20:        //sEntryByx            
-            case 22:        //sApproved           
-            case 24:        //sModified            
-            case 26:        //sDeptName
-            case 27:        //sCompnyNm
-            case 28:        //sBranchNm   
-            case 29:        //sTownxxxx
-            case 30:        //sProvIDxx
-            case 31:        //sProvName
+            case 5 :        //sActSrcex                       
+            case 8:        //sLocation 
+            case 9:        //sCompnynx           
+            case 13:        //sEmployID 
+            case 14:        //sDeptIDxx
+            case 15:        //sLogRemrk 
+            case 16:        //sRemarksx             
+            case 18:        //sEntryByx            
+            case 20:        //sApproved           
+            case 22:        //sModified            
+            case 24:        //sDeptName
+            case 25:        //sCompnyNm
+            case 26:        //sBranchNm               
+            case 27:        //sProvIDxx
+            case 28:        //sProvName                                                                                                        
                 poMaster.updateObject(fnIndex, (String) foValue);
                 poMaster.updateRow();
                 
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
-                break;
-            case 12:        //nPropBdgt 
-            case 13:        //nRcvdBdgt 
-            case 14:        //nTrgtClnt           
-            case 19:        //cTranStat           
+                break;                 
+            case 10:        //nPropBdgt 
+            case 11:        //nRcvdBdgt 
+            case 12:        //nTrgtClnt           
+            case 17:        //cTranStat           
                 if (foValue instanceof Integer)
                     poMaster.updateInt(fnIndex, (int) foValue);
                 else 
@@ -119,9 +117,9 @@ public class Activity {
                 break;              
             case 6 :        //dDateFrom 
             case 7 :        //dDateThru
-            case 21:        //dEntryDte 
-            case 23:        //dApproved 
-            case 25:        //dModified 
+            case 19:        //dEntryDte 
+            case 21:        //dApproved 
+            case 23:        //dModified 
                 if (foValue instanceof Date){
                     poMaster.updateObject(fnIndex, foValue);
                 } else {
@@ -137,6 +135,7 @@ public class Activity {
     public void setMaster(String fsIndex, Object foValue) throws SQLException{
         setMaster(MiscUtil.getColumnIndex(poMaster, fsIndex), foValue);
     }
+    
     //Activity Master getter
     public Object getMaster(String fsIndex) throws SQLException{
         return getMaster(MiscUtil.getColumnIndex(poMaster, fsIndex));
@@ -188,27 +187,44 @@ public class Activity {
 
             poMaster.insertRow();
             poMaster.moveToCurrentRow();     
-            //---------------------------------Activity Member------------------
-            lsSQL = getSQ_ActMember()+ " WHERE 0=1";
-            //String lsSQL = MiscUtil.addCondition(getSQ_Master(), "0=1"); 
-            //System.out.println(lsSQL);
-            loRS = poGRider.executeQuery(lsSQL);
+//            //---------------------------------Activity Member------------------            
+//            lsSQL = MiscUtil.addCondition(getSQ_ActMember(), "0=1"); 
+//            //System.out.println(lsSQL);
+//            loRS = poGRider.executeQuery(lsSQL);
+//            
+//            poActMember = factory.createCachedRowSet();
+//            poActMember.populate(loRS);
+//            MiscUtil.close(loRS);
+//            
+//            poActMember.last();
+//            poActMember.moveToInsertRow();
+//            
+//            MiscUtil.initRowSet(poActMember);       
+//            //poMaster.updateString("cRecdStat", RecordStatus.ACTIVE);            
+////            poActMember.updateString("cTranStat", "0");
+////            poActMember.updateObject("dDateFrom", poGRider.getServerDate());    
+////            poActMember.updateObject("dDateThru", poGRider.getServerDate());                       
+//
+//            poActMember.insertRow();
+//            poActMember.moveToCurrentRow();    
+//            //---------------------------------Activity Town------------------            
+//            lsSQL = MiscUtil.addCondition(getSQ_ActivityTown(), "0=1"); 
+//            //System.out.println(lsSQL);
+//            loRS = poGRider.executeQuery(lsSQL);
+//            
+//            poTown = factory.createCachedRowSet();
+//            poTown.populate(loRS);
+//            MiscUtil.close(loRS);
+//            
+//            poTown.last();
+//            poTown.moveToInsertRow();
+//            
+//            MiscUtil.initRowSet(poTown);       
+//
+//            poTown.insertRow();
+//            poTown.moveToCurrentRow();    
+//            
             
-            poActMember = factory.createCachedRowSet();
-            poActMember.populate(loRS);
-            MiscUtil.close(loRS);
-            
-            poActMember.last();
-            poActMember.moveToInsertRow();
-            
-            MiscUtil.initRowSet(poActMember);       
-            //poMaster.updateString("cRecdStat", RecordStatus.ACTIVE);            
-//            poActMember.updateString("cTranStat", "0");
-//            poActMember.updateObject("dDateFrom", poGRider.getServerDate());    
-//            poActMember.updateObject("dDateThru", poGRider.getServerDate());                       
-
-            poActMember.insertRow();
-            poActMember.moveToCurrentRow();         
         } catch (SQLException e) {
             psMessage = e.getMessage();
             return false;
@@ -223,6 +239,172 @@ public class Activity {
     }
     
     public boolean SaveRecord(){
+        if (!(pnEditMode == EditMode.ADDNEW || pnEditMode == EditMode.UPDATE)){
+            psMessage = "Invalid update mode detected.";
+            return false;
+        }
+        
+        try {
+            if (!isEntryOK()) return false;
+            
+            String lsSQL = "";
+            int lnCtr;
+            
+            if (pnEditMode == EditMode.ADDNEW){ //add
+                if (!pbWithParent) poGRider.beginTrans();
+                //-------------------SAVE ACTIIVTY MASTER------------------------
+                String lsTransNox =  MiscUtil.getNextCode(MASTER_TABLE, "sActvtyID", true, poGRider.getConnection(), psBranchCd); 
+                poMaster.updateObject("sActvtyID", lsTransNox);
+                poMaster.updateString("sEntryByx", poGRider.getUserID());
+                poMaster.updateObject("dEntryDte", (Date) poGRider.getServerDate());
+                poMaster.updateString("sModified", poGRider.getUserID());
+                poMaster.updateObject("dModified", (Date) poGRider.getServerDate());
+                poMaster.updateRow();
+                
+                lsSQL = MiscUtil.rowset2SQL(poMaster, MASTER_TABLE, "sDeptName»sCompnyNm»sProvName»sBranchNm");
+                
+                if (poGRider.executeQuery(lsSQL, MASTER_TABLE, psBranchCd, "") <= 0){
+                    psMessage = poGRider.getErrMsg();
+                    if (!pbWithParent) poGRider.rollbackTrans();
+                        return false;
+                }
+                
+                //-------------------SAVE ACTIVITY MEMBER----------------------
+                
+                if (getActMemberCount()> 0){
+                    lnCtr = 1;
+                    poActMember.beforeFirst();
+                    while (poActMember.next()){
+                        poActMember.updateObject("sTransNox", lsTransNox);
+                        poActMember.updateObject("nEntryNox", lnCtr);
+                        poActMember.updateObject("sEntryByx", poGRider.getUserID());
+                        poActMember.updateObject("dEntryDte", (Date) poGRider.getServerDate());                    
+                        poActMember.updateRow();
+
+                        lsSQL = MiscUtil.rowset2SQL(poActMember, "activity_member","sCompnyNm»sDeptName");
+                        //TODO what is substring(0,4)
+                        if (poGRider.executeQuery(lsSQL, "activity_member", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
+                            if (!pbWithParent) poGRider.rollbackTrans();
+                            psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
+                            return false;
+                        }
+
+                        lnCtr++;
+                    }
+                }
+                //-------------------SAVE ACTIVITY Town----------------------
+                
+                if (getTownCount()> 0){
+                    lnCtr = 1;
+                    poTown.beforeFirst();
+                    while (poTown.next()){
+                        poTown.updateObject("sTransNox", lsTransNox);                                           
+                        poTown.updateRow();
+
+                        lsSQL = MiscUtil.rowset2SQL(poTown, "activity_town","sTownName");
+                        //TODO what is substring(0,4)
+                        if (poGRider.executeQuery(lsSQL, "activity_town", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
+                            if (!pbWithParent) poGRider.rollbackTrans();
+                            psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
+                            return false;
+                        }
+
+                        lnCtr++;
+                    }
+                }
+                                
+            } else { //update 
+                if (!pbWithParent) poGRider.beginTrans();
+                
+                //set transaction number on records
+                String lsTransNox = (String) getMaster("sActvtyID");
+                
+                poMaster.updateString("sModified", poGRider.getUserID());
+                poMaster.updateObject("dModified", (Date) poGRider.getServerDate());
+                poMaster.updateRow();
+                
+                lsSQL = MiscUtil.rowset2SQL(poMaster, 
+                                            MASTER_TABLE, 
+                                            "sDeptName»sCompnyNm»sProvName»sBranchNm",                                            
+                                            "sTransNox = " + SQLUtil.toSQL(lsTransNox));
+                if (poGRider.executeQuery(lsSQL, MASTER_TABLE, psBranchCd, "") <= 0){
+                    psMessage = poGRider.getErrMsg();
+                    if (!pbWithParent) poGRider.rollbackTrans();
+                        return false;
+                }                                                            
+                //----------------------Activity member update-------------------
+                if (getActMemberCount()> 0){
+                    lnCtr = 1;
+                    poActMember.beforeFirst();
+                    while (poActMember.next()){
+                        String lsfTransNox = (String) getActMember(lnCtr, "sTransNox");// check if user added new VEHICLE PRIORITY to insert
+                        if (lsfTransNox.equals("") || lsfTransNox.isEmpty()){
+                            poActMember.updateObject("sTransNox", lsTransNox);
+                            poActMember.updateObject("sEntryByx", poGRider.getUserID());
+                            poActMember.updateObject("dEntryDte", (Date) poGRider.getServerDate());                    
+                            poActMember.updateRow();
+
+                            lsSQL = MiscUtil.rowset2SQL(poActMember, "activity_member","sCompnyNm»sDeptName");
+                            //TODO what is substring(0,4)
+                            if (poGRider.executeQuery(lsSQL, "activity_member", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
+                                if (!pbWithParent) poGRider.rollbackTrans();
+                                psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
+                                return false;
+                            }
+                        }else{
+                            lsSQL = MiscUtil.rowset2SQL(poActMember, 
+                                                        "activity_member", 
+                                                        "sCompnyNm»sDeptName", 
+                                                        "sTransNox = " + SQLUtil.toSQL(lsTransNox) + 
+                                                            " AND sEmployID = " + SQLUtil.toSQL(poActMember.getString("sEmployID")));
+
+                            if (!lsSQL.isEmpty()){
+                                if (poGRider.executeQuery(lsSQL, "activity_member", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
+                                    if (!pbWithParent) poGRider.rollbackTrans();
+                                    psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                    return false;
+                                }
+                            }
+                        }
+
+                        lnCtr++;
+                    }
+                }
+                //----------------------Activity Town update-_------------------
+                if (getTownCount()> 0){
+                    lnCtr = 1;
+                    poTown.beforeFirst();
+                    while (poTown.next()){
+                        String lsfTransNox = (String) getActMember(lnCtr, "sTransNox");// check if user added new VEHICLE PRIORITY to insert
+                        if (lsfTransNox.equals("") || lsfTransNox.isEmpty()){
+                            poTown.updateObject("sTransNox", lsTransNox);                                           
+                            poTown.updateRow();
+
+                            lsSQL = MiscUtil.rowset2SQL(poTown, "activity_town","sTownName");
+                            //TODO what is substring(0,4)
+                            if (poGRider.executeQuery(lsSQL, "activity_town", psBranchCd, lsTransNox.substring(0, 4)) <= 0){
+                                if (!pbWithParent) poGRider.rollbackTrans();
+                                psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
+                                return false;
+                            }
+                        }
+                        lnCtr++;
+                    }
+                }
+            }
+            
+            if (lsSQL.isEmpty()){
+                psMessage = "No record to update.";
+                return false;
+            }                                                       
+            
+            if (!pbWithParent) poGRider.commitTrans();
+        } catch (SQLException e) {
+            psMessage = e.getMessage();
+            return false;
+        }
+        
+        pnEditMode = EditMode.READY;
         return true;
     }
     
@@ -349,38 +531,34 @@ public class Activity {
                     " ,a.sActTypID " + //4
                     " ,a.sActSrcex " + //5
                     " ,a.dDateFrom " + //6
-                    " ,a.dDateThru " + //7
-                    " ,a.sAddressx " + //8
-                    " ,a.sTownIDxx " + //9
-                    " ,a.sLocation " + //10
-                    " ,a.sCompnynx " + //11
-                    " ,a.nPropBdgt " + //12
-                    " ,a.nRcvdBdgt " + //13
-                    " ,a.nTrgtClnt " + //14
-                    " ,a.sEmployID " + //15
-                    " ,a.sDeptIDxx " + //16
-                    " ,a.sLogRemrk " + //17
-                    " ,a.sRemarksx " + //18 
-                    " ,a.cTranStat " + //19
-                    " ,a.sEntryByx " + //20
-                    " ,a.dEntryDte " + //21
-                    " ,a.sApproved " + //22
-                    " ,a.dApproved " + //23
-                    " ,a.sModified " + //24
-                    " ,a.dModified " + //25
-                    " ,IFNULL(b.sDeptName , '') sDeptName " + //26
-                    " ,IFNULL(d.sCompnyNm , '') sCompnyNm " + //27
-                    " ,IFNULL(e.sBranchNm , '') sBranchNm " + //28
-                    " ,a.sTownxxxx " + //29
-                    " ,a.sProvIDxx " + //30
-                    " ,IFNULL(f.sProvName , '') sProvName " +//31
+                    " ,a.dDateThru " + //7                   
+                    " ,a.sLocation " + //8
+                    " ,a.sCompnynx " + //9
+                    " ,a.nPropBdgt " + //10
+                    " ,a.nRcvdBdgt " + //11
+                    " ,a.nTrgtClnt " + //12
+                    " ,a.sEmployID " + //13
+                    " ,a.sDeptIDxx " + //14
+                    " ,a.sLogRemrk " + //15
+                    " ,a.sRemarksx " + //16 
+                    " ,a.cTranStat " + //17
+                    " ,a.sEntryByx " + //18
+                    " ,a.dEntryDte " + //19
+                    " ,a.sApproved " + //20
+                    " ,a.dApproved " + //21
+                    " ,a.sModified " + //22
+                    " ,a.dModified " + //23
+                    " ,IFNULL(b.sDeptName , '') sDeptName " + //24
+                    " ,IFNULL(d.sCompnyNm , '') sCompnyNm " + //25
+                    " ,IFNULL(e.sBranchNm , '') sBranchNm " + //26                 
+                    " ,a.sProvIDxx " + //27
+                    " ,IFNULL(f.sProvName , '') sProvName " +//28              
                 " FROM ggc_anyautodbf.activity_master a " +
                 " LEFT JOIN ggc_isysdbf.department b ON b.sDeptIDxx = a.sDeptIDxx " +
                 " LEFT JOIN ggc_isysdbf.Employee_Master001 c ON c.sEmployID = a.sEmployID " +
                 " LEFT JOIN ggc_isysdbf.client_master d ON d.sClientID = a.sEmployID " +
                 " LEFT JOIN ggc_anyautodbf.branch e ON e.sBranchCd = a.sLocation "  +
-                " LEFT JOIN province f ON f.sProvIDxx = a.sProvIDxx " +
-                " LEFT JOIN towncity g on g.sTownIDxx = a.sTownIDxx ";       
+                " LEFT JOIN province f ON f.sProvIDxx = a.sProvIDxx ";                      
     }
     
     private String getSQ_Department(){
@@ -468,7 +646,7 @@ public class Activity {
             return false;
         }
         
-        pnEditMode = EditMode.READY;
+        //pnEditMode = EditMode.READY;
         return true;               
     }
             
@@ -639,7 +817,7 @@ public class Activity {
             return false;
         }
         
-        pnEditMode = EditMode.READY;
+        //pnEditMode = EditMode.READY;
         return true;                                                
     }
     
@@ -696,7 +874,7 @@ public class Activity {
                 poActMember.updateObject(fnIndex, (String) foValue);
                 poActMember.updateRow();
                 
-                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getActMember(fnIndex));
                 break;
             case 2 ://nEntryNox                            
                 if (foValue instanceof Integer)
@@ -705,7 +883,7 @@ public class Activity {
                     poActMember.updateInt(fnIndex, 0);
                 
                 poActMember.updateRow();
-                if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));  
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getActMember(fnIndex));  
                 break;             
         }            
     }   
@@ -713,6 +891,17 @@ public class Activity {
     public void setActMember(int fnRow, String fsIndex, Object foValue) throws SQLException{
         setActMember(fnRow,MiscUtil.getColumnIndex(poActMember, fsIndex), foValue);
     }
+    
+    //Activity member getter
+    public Object getActMember(String fsIndex) throws SQLException{
+        return getActMember(MiscUtil.getColumnIndex(poActMember, fsIndex));
+    }
+    //Activity member getter
+    public Object getActMember(int fnIndex) throws SQLException{
+        poActMember.first();
+        return poActMember.getObject(fnIndex);
+    }
+        
     //Activity Member GETTER    
     public Object getActMember(int fnRow, int fnIndex) throws SQLException{
         if (fnIndex == 0) return null;
@@ -774,6 +963,46 @@ public class Activity {
                 " WHERE a.cRecdStat = '1' " ;
     }
     
+    private String getSQ_ActivityTown(){
+        return  " SELECT " +
+                    " a.sTransNox " +
+                    " ,a.sTownIDxx " +
+                    " ,a.sAddressx " +
+                    " ,IFNULL(b.sTownName, '') sTownName " +                    
+                " From activity_town a " +
+                " LEFT JOIN towncity b on b.sTownIDxx = a.sTownIDxx ";                
+    }
+    
+    //Activity Town Setter
+    public void setActTown(int fnRow, int fnIndex, Object foValue) throws SQLException{        
+        poTown.absolute(fnRow);         
+        switch (fnIndex){  
+            case 1 ://sTransNox  
+            case 2 ://sTownIDxx
+            case 3 ://sAddressx  
+            case 4: //sTownName
+                poTown.updateObject(fnIndex, (String) foValue);
+                poTown.updateRow();
+                
+                if (poCallback != null) poCallback.onSuccess(fnIndex, getTown(fnIndex));
+                break;                      
+        }            
+    }   
+    
+    public void setActTown(int fnRow, String fsIndex, Object foValue) throws SQLException{
+        setActTown(fnRow,MiscUtil.getColumnIndex(poTown, fsIndex), foValue);
+    }
+    
+    //Activity Town getter
+    public Object getTown(String fsIndex) throws SQLException{
+        return getTown(MiscUtil.getColumnIndex(poTown, fsIndex));
+    }
+    //Activity Town getter
+    public Object getTown(int fnIndex) throws SQLException{
+        poTown.first();
+        return poTown.getObject(fnIndex);
+    }
+    
     //Town GETTER    
     public Object getTown(int fnRow, int fnIndex) throws SQLException{
         if (fnIndex == 0) return null;
@@ -787,7 +1016,7 @@ public class Activity {
         return getTown(fnRow, MiscUtil.getColumnIndex(poTown, fsIndex));
     }        
     
-    //get rowcount of Activity Member
+    //get rowcount of Activity Town
     public int getTownCount() throws SQLException{
         try {
             if (poTown != null){
@@ -802,13 +1031,39 @@ public class Activity {
         }
     }   
     
+    public boolean addTown(String fsTownID, String fsTownName) throws SQLException{   
+        if (poTown == null){
+            String lsSQL = MiscUtil.addCondition(getSQ_ActivityTown(), "0=1");
+            ResultSet loRS = poGRider.executeQuery(lsSQL);
+            System.out.println(lsSQL);
+            RowSetFactory factory = RowSetProvider.newFactory();
+            poTown = factory.createCachedRowSet();
+            poTown.populate(loRS);
+            MiscUtil.close(loRS);
+        }
+        
+        poTown.last();
+        poTown.moveToInsertRow();
+
+        MiscUtil.initRowSet(poTown);  
+          
+        poTown.updateString("sTownIDxx", fsTownID);
+        poTown.updateString("sTownName", fsTownName);    
+        poTown.insertRow();
+        poTown.moveToCurrentRow();
+                
+        return true;               
+    }
     /**
-        * Loads the town data based on the provided value.
+        * Loads town data based on the provided value.
         *
-        * @param fsValue the value used to filter the town data
-        * @return true if the town data was successfully loaded, false otherwise
+        * @param fsValue   The value to use for loading the town data.
+        * @param fbByLoad  Determines whether to load the town data by a specific condition or activity town.
+        *                  - If true, the town data will be loaded based on the condition "a.sProvIDxx = fsValue".
+        *                  - If false, the town data will be loaded based on the activity town condition "a.sTransNox = fsValue".
+        * @return True if the town data was successfully loaded, False otherwise.
     */
-    public boolean loadTown(String fsValue){
+    public boolean loadTown(String fsValue, boolean fbByLoad){
         try {
             if (poGRider == null){
                 psMessage = "Application driver is not set.";
@@ -817,8 +1072,11 @@ public class Activity {
             String lsSQL;
             ResultSet loRS;
             RowSetFactory factory = RowSetProvider.newFactory();
-                        
-            lsSQL = MiscUtil.addCondition(getSQ_Town(), "a.sProvIDxx = " + SQLUtil.toSQL(fsValue));                                                                       
+            if (fbByLoad)  {         
+                lsSQL = MiscUtil.addCondition(getSQ_Town(), "a.sProvIDxx = " + SQLUtil.toSQL(fsValue));    
+            }else{
+                lsSQL = MiscUtil.addCondition(getSQ_ActivityTown(), "a.sTransNox = " + SQLUtil.toSQL(fsValue));  
+            }
              
             System.out.println(lsSQL);             
             loRS = poGRider.executeQuery(lsSQL);            
@@ -867,7 +1125,7 @@ public class Activity {
             loRS = poGRider.executeQuery(lsSQL);
             System.out.println(lsSQL);
             if (loRS.next()){
-                setMaster("a.sProvIDxx", loRS.getString("sProvIDxx"));
+                setMaster("sProvIDxx", loRS.getString("sProvIDxx"));
                 setMaster("sProvName", loRS.getString("sProvName"));               
             } else {
                 psMessage = "No record found.";
@@ -888,7 +1146,7 @@ public class Activity {
                 psMessage = "No record found/selected.";
                 return false;
             } else {
-                setMaster("a.sProvIDxx", (String) loJSON.get("sProvIDxx"));
+                setMaster("sProvIDxx", (String) loJSON.get("sProvIDxx"));
                 setMaster("sProvName", (String) loJSON.get("sProvName"));                
             }
         }        
@@ -948,4 +1206,7 @@ public class Activity {
         System.out.println("----------------------------------------");
     } 
     
+    public boolean isEntryOK(){
+        return true;
+    }
 }

--- a/src/org/rmj/auto/clients/base/ClientAddress.java
+++ b/src/org/rmj/auto/clients/base/ClientAddress.java
@@ -334,7 +334,7 @@ public class ClientAddress {
             psMessage = "Invalid update mode detected.";
             return false;
         }
-        boolean isModified = false;
+        //boolean isModified = false;
         try {
             //dont save if no item
             if (getItemCount() > 0){  
@@ -343,12 +343,13 @@ public class ClientAddress {
                 String lsSQL = "";
                 int lnCtr;            
                 if (pnEditMode == EditMode.ADDNEW){ //add
-                    isModified = true;
+                    //isModified = true;
                     lnCtr = 1;                
-                    //poAddress.beforeFirst();
-                    //while (poAddress.next()){
+                    
                     if (!pbWithParent) poGRider.beginTrans(); 
-                    while (lnCtr <= getItemCount()){
+                    poAddress.beforeFirst();
+                    while (poAddress.next()){
+                    //while (lnCtr <= getItemCount()){
                         String lsAddrssID = MiscUtil.getNextCode(ADDRESS_TABLE, "sAddrssID", true, poGRider.getConnection(), psBranchCd);
                         poAddress.updateString("sClientID", psClientID);                    
                         poAddress.updateObject("sAddrssID", lsAddrssID);
@@ -374,54 +375,56 @@ public class ClientAddress {
                 } else { //update                                    
                     //check if changes has been made
 
-                    poAddress.beforeFirst();
-                    lnCtr = 1;
-                    while (lnCtr <= getItemCount()){
-                        if (!CompareRows.isRowEqual(poAddress, poOriginalAddress)) {
-                            isModified = true;
-                            break;
-                        }
-                        lnCtr++;
-                    }
-                    if (isModified) {                     
+//                    poAddress.beforeFirst();
+//                    lnCtr = 1;
+//                    while (lnCtr <= getItemCount()){
+//                        if (!CompareRows.isRowEqual(poAddress, poOriginalAddress)) {
+//                            isModified = true;
+//                            break;
+//                        }
+//                        lnCtr++;
+//                    }
+                    //if (isModified) {                     
                         // Save the changes
                         lnCtr = 1;
                         poAddress.beforeFirst();
                         //while (poAddress.next()){
                         while (lnCtr <= getItemCount()){
-                            String lsAddrssID = (String) getAddress(lnCtr, "sAddrssID");// check if user added new address to insert
-                            if (lsAddrssID.equals("") || lsAddrssID.isEmpty()){
-                                lsAddrssID = MiscUtil.getNextCode(ADDRESS_TABLE, "sAddrssID", true, poGRider.getConnection(), psBranchCd);
-                                poAddress.updateString("sClientID", psClientID);                 
-                                poAddress.updateObject("sAddrssID", lsAddrssID);
-                                poAddress.updateString("sEntryByx", poGRider.getUserID());
-                                poAddress.updateObject("dEntryDte", (Date) poGRider.getServerDate());
-                                poAddress.updateString("sModified", poGRider.getUserID());
-                                poAddress.updateObject("dModified", (Date) poGRider.getServerDate());
-                                poAddress.updateRow();
+                            if(!CompareRows.isRowEqual(poAddress, poOriginalAddress,lnCtr)) {                                
+                                String lsAddrssID = (String) getAddress(lnCtr, "sAddrssID");// check if user added new address to insert
+                                if (lsAddrssID.equals("") || lsAddrssID.isEmpty()){
+                                    lsAddrssID = MiscUtil.getNextCode(ADDRESS_TABLE, "sAddrssID", true, poGRider.getConnection(), psBranchCd);
+                                    poAddress.updateString("sClientID", psClientID);                 
+                                    poAddress.updateObject("sAddrssID", lsAddrssID);
+                                    poAddress.updateString("sEntryByx", poGRider.getUserID());
+                                    poAddress.updateObject("dEntryDte", (Date) poGRider.getServerDate());
+                                    poAddress.updateString("sModified", poGRider.getUserID());
+                                    poAddress.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    poAddress.updateRow();
 
-                                lsSQL = MiscUtil.rowset2SQL(poAddress, ADDRESS_TABLE, "sProvName»sBrgyName»sTownName");
+                                    lsSQL = MiscUtil.rowset2SQL(poAddress, ADDRESS_TABLE, "sProvName»sBrgyName»sTownName");
 
-                                if (poGRider.executeQuery(lsSQL, ADDRESS_TABLE, psBranchCd, lsAddrssID.substring(0, 4)) <= 0){
-                                    if (!pbWithParent) poGRider.rollbackTrans();
-                                    psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
-                                    return false;
-                                }
-                            }else{//if user modified already saved address   
-                                poAddress.updateString("sModified", poGRider.getUserID());
-                                poAddress.updateObject("dModified", (Date) poGRider.getServerDate());
-                                poAddress.updateRow();
-                                lsSQL = MiscUtil.rowset2SQL(poAddress, 
-                                                            ADDRESS_TABLE, 
-                                                            "sProvName»sBrgyName»sTownName", 
-                                                            "sAddrssID = " + SQLUtil.toSQL(lsAddrssID) +
-                                                            " AND sClientID = " + SQLUtil.toSQL((String) getAddress(lnCtr,"sClientID")));
-
-                                if (!lsSQL.isEmpty()){
                                     if (poGRider.executeQuery(lsSQL, ADDRESS_TABLE, psBranchCd, lsAddrssID.substring(0, 4)) <= 0){
                                         if (!pbWithParent) poGRider.rollbackTrans();
-                                        psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                        psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
                                         return false;
+                                    }
+                                }else{//if user modified already saved address   
+                                    poAddress.updateString("sModified", poGRider.getUserID());
+                                    poAddress.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    poAddress.updateRow();
+                                    lsSQL = MiscUtil.rowset2SQL(poAddress, 
+                                                                ADDRESS_TABLE, 
+                                                                "sProvName»sBrgyName»sTownName", 
+                                                                "sAddrssID = " + SQLUtil.toSQL(lsAddrssID) +
+                                                                " AND sClientID = " + SQLUtil.toSQL((String) getAddress(lnCtr,"sClientID")));
+
+                                    if (!lsSQL.isEmpty()){
+                                        if (poGRider.executeQuery(lsSQL, ADDRESS_TABLE, psBranchCd, lsAddrssID.substring(0, 4)) <= 0){
+                                            if (!pbWithParent) poGRider.rollbackTrans();
+                                            psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                            return false;
+                                        }
                                     }
                                 }
                             }
@@ -429,7 +432,7 @@ public class ClientAddress {
                         }                    
                         // Update the original state of the table
                         poOriginalAddress = (CachedRowSet) poAddress.createCopy();
-                    }
+                    //}
                 }
 
 //                if (lsSQL.isEmpty() && isModified == true){

--- a/src/org/rmj/auto/clients/base/ClientAddress.java
+++ b/src/org/rmj/auto/clients/base/ClientAddress.java
@@ -285,7 +285,7 @@ public class ClientAddress {
         try {
             String lsSQL;
             ResultSet loRS;
-            //RowSetFactory factory = RowSetProvider.newFactory();
+            RowSetFactory factory = RowSetProvider.newFactory();
             //open master
             if (fbByUserID)
                 lsSQL = MiscUtil.addCondition(getSQ_Address(), "a.sAddrssID = " + SQLUtil.toSQL(fsValue));
@@ -294,13 +294,13 @@ public class ClientAddress {
             
             loRS = poGRider.executeQuery(lsSQL);
             
-            if (MiscUtil.RecordCount(loRS) <= 0){
-                psMessage = "No record found.";
-                MiscUtil.close(loRS);        
-                return false;
-            }
+//            if (MiscUtil.RecordCount(loRS) <= 0){
+//                psMessage = "No record found.";
+//                MiscUtil.close(loRS);        
+//                return false;
+//            }
             
-            RowSetFactory factory = RowSetProvider.newFactory();
+            //RowSetFactory factory = RowSetProvider.newFactory();
             poAddress = factory.createCachedRowSet();
             poAddress.populate(loRS);
             MiscUtil.close(loRS);

--- a/src/org/rmj/auto/clients/base/ClientEMail.java
+++ b/src/org/rmj/auto/clients/base/ClientEMail.java
@@ -238,51 +238,53 @@ public class ClientEMail {
                     if (!pbWithParent) poGRider.beginTrans();
                     //check if changes has been made                
                     //poEmail.beforeFirst();
-                    lnCtr = 1;
-                    while (lnCtr <= getItemCount()){
-                        if (!CompareRows.isRowEqual(poEmail, poOriginalEmail)) {
-                            isModified = true;
-                            break;
-                        }
-                        lnCtr++;
-                    }
-                    if (isModified) {
+//                    lnCtr = 1;
+//                    while (lnCtr <= getItemCount()){
+//                        if (!CompareRows.isRowEqual(poEmail, poOriginalEmail)) {
+//                            isModified = true;
+//                            break;
+//                        }
+//                        lnCtr++;
+//                    }
+                    //if (isModified) {
                         // Save the changes
                         lnCtr = 1;
-                        while (lnCtr <= getItemCount()){                      
-                            String lsEmailID = (String) getEmail(lnCtr, "sEmailIDx");
-                            if (lsEmailID.equals("") || lsEmailID.isEmpty()){// check if user added new email to insert
-                                lsEmailID = MiscUtil.getNextCode(EMAIL_TABLE, "sEmailIDx", true, poGRider.getConnection(), psBranchCd);
-                                poEmail.updateString("sClientID", psClientID);                           
-                                poEmail.updateObject("sEmailIDx", lsEmailID);
-                                poEmail.updateString("sEntryByx", poGRider.getUserID());
-                                poEmail.updateObject("dEntryDte", (Date) poGRider.getServerDate());
-                                poEmail.updateString("sModified", poGRider.getUserID());
-                                poEmail.updateObject("dModified", (Date) poGRider.getServerDate());
-                                poEmail.updateRow();
+                        while (lnCtr <= getItemCount()){  
+                            if(!CompareRows.isRowEqual(poEmail, poOriginalEmail,lnCtr)) {
+                                String lsEmailID = (String) getEmail(lnCtr, "sEmailIDx");
+                                if (lsEmailID.equals("") || lsEmailID.isEmpty()){// check if user added new email to insert
+                                    lsEmailID = MiscUtil.getNextCode(EMAIL_TABLE, "sEmailIDx", true, poGRider.getConnection(), psBranchCd);
+                                    poEmail.updateString("sClientID", psClientID);                           
+                                    poEmail.updateObject("sEmailIDx", lsEmailID);
+                                    poEmail.updateString("sEntryByx", poGRider.getUserID());
+                                    poEmail.updateObject("dEntryDte", (Date) poGRider.getServerDate());
+                                    poEmail.updateString("sModified", poGRider.getUserID());
+                                    poEmail.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    poEmail.updateRow();
 
-                                lsSQL = MiscUtil.rowset2SQL(poEmail, EMAIL_TABLE, "");
+                                    lsSQL = MiscUtil.rowset2SQL(poEmail, EMAIL_TABLE, "");
 
-                                if (poGRider.executeQuery(lsSQL, EMAIL_TABLE, psBranchCd, lsEmailID.substring(0, 4)) <= 0){
-                                    if (!pbWithParent) poGRider.rollbackTrans();
-                                    psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
-                                    return false;
-                                }
-                            }else{
-                                poEmail.updateString("sModified", poGRider.getUserID());
-                                poEmail.updateObject("dModified", (Date) poGRider.getServerDate());
-                                poEmail.updateRow();
-                                lsSQL = MiscUtil.rowset2SQL(poEmail, 
-                                                            EMAIL_TABLE, 
-                                                            "", 
-                                                            "sEmailIDx = " + SQLUtil.toSQL(lsEmailID) +
-                                                            " AND sClientID = " + SQLUtil.toSQL((String) getEmail(lnCtr,"sClientID")));
-
-                                if (!lsSQL.isEmpty() && isModified == true){
                                     if (poGRider.executeQuery(lsSQL, EMAIL_TABLE, psBranchCd, lsEmailID.substring(0, 4)) <= 0){
                                         if (!pbWithParent) poGRider.rollbackTrans();
-                                        psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                        psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
                                         return false;
+                                    }
+                                }else{
+                                    poEmail.updateString("sModified", poGRider.getUserID());
+                                    poEmail.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    poEmail.updateRow();
+                                    lsSQL = MiscUtil.rowset2SQL(poEmail, 
+                                                                EMAIL_TABLE, 
+                                                                "", 
+                                                                "sEmailIDx = " + SQLUtil.toSQL(lsEmailID) +
+                                                                " AND sClientID = " + SQLUtil.toSQL((String) getEmail(lnCtr,"sClientID")));
+
+                                    if (!lsSQL.isEmpty() && isModified == true){
+                                        if (poGRider.executeQuery(lsSQL, EMAIL_TABLE, psBranchCd, lsEmailID.substring(0, 4)) <= 0){
+                                            if (!pbWithParent) poGRider.rollbackTrans();
+                                            psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                            return false;
+                                        }
                                     }
                                 }
                             }
@@ -290,7 +292,7 @@ public class ClientEMail {
                         }
                         // Update the original state of the table
                         poOriginalEmail = (CachedRowSet) poEmail.createCopy();
-                    }
+                    //}
                 }
 
 //                if (lsSQL.isEmpty() && isModified == true){

--- a/src/org/rmj/auto/clients/base/ClientMaster.java
+++ b/src/org/rmj/auto/clients/base/ClientMaster.java
@@ -94,7 +94,7 @@ public class ClientMaster {
             case 24://sCntryNme
             case 25://sTownName
             case 27://sSpouseID
-            case 28://sSpouseNm
+            case 28://sSpouseNm                
                 poMaster.updateObject(fnIndex, (String) foValue);
                 poMaster.updateRow();
                 

--- a/src/org/rmj/auto/clients/base/ClientMobile.java
+++ b/src/org/rmj/auto/clients/base/ClientMobile.java
@@ -211,7 +211,7 @@ public class ClientMobile {
             return false;
         }
         
-        boolean isModified = false;
+        //boolean isModified = false;
         
         try {
             //dont save if no item
@@ -222,7 +222,7 @@ public class ClientMobile {
                 int lnCtr;
 
                 if (pnEditMode == EditMode.ADDNEW){ //add
-                    isModified = true;
+                    //isModified = true;
                     lnCtr = 1;
                     poMobile.beforeFirst();
                     while (poMobile.next()){
@@ -254,54 +254,56 @@ public class ClientMobile {
                     if (!pbWithParent) poGRider.beginTrans();
 
                     //check if changes has been made                
-                    lnCtr = 1;
-                    while (lnCtr <= getItemCount()){
-                        if (!CompareRows.isRowEqual(poMobile, poOriginalMobile)) {
-                            isModified = true;
-                            break;
-                        }
-                        lnCtr++;
-                    }
-
-                    if (isModified) {
+//                    lnCtr = 1;
+//                    while (lnCtr <= getItemCount()){
+//                        if (!CompareRows.isRowEqual(poMobile, poOriginalMobile)) {
+//                            isModified = true;
+//                            break;
+//                        }
+//                        lnCtr++;
+//                    }
+//
+//                    if (isModified) {
                         // Save the changes
                         lnCtr = 1;
-                        while (lnCtr <= getItemCount()){                    
-                            String lsMobileID = (String) getMobile(lnCtr, "sMobileID");
-                            if (lsMobileID.equals("") || lsMobileID.isEmpty()){// check if user added new mobile to insert
-                                lsMobileID = MiscUtil.getNextCode(MOBILE_MASTER, "sMobileID", true, poGRider.getConnection(), psBranchCd);
-                                poMobile.updateString("sClientID", psClientID);
-                                //poMobile.updateString("sClientID", lsMobileID);//temp only
-                                poMobile.updateObject("sMobileID", lsMobileID);
-                                poMobile.updateObject("cSubscrbr", CommonUtils.classifyNetwork((String)getMobile(lnCtr, "sMobileNo")));
-                                poMobile.updateString("sEntryByx", poGRider.getUserID());
-                                poMobile.updateObject("dEntryDte", (Date) poGRider.getServerDate());
-                                poMobile.updateString("sModified", poGRider.getUserID());
-                                poMobile.updateObject("dModified", (Date) poGRider.getServerDate());
-                                poMobile.updateRow();
+                        while (lnCtr <= getItemCount()){ 
+                            if(!CompareRows.isRowEqual(poMobile, poOriginalMobile,lnCtr)) {
+                                String lsMobileID = (String) getMobile(lnCtr, "sMobileID");
+                                if (lsMobileID.equals("") || lsMobileID.isEmpty()){// check if user added new mobile to insert
+                                    lsMobileID = MiscUtil.getNextCode(MOBILE_MASTER, "sMobileID", true, poGRider.getConnection(), psBranchCd);
+                                    poMobile.updateString("sClientID", psClientID);
+                                    //poMobile.updateString("sClientID", lsMobileID);//temp only
+                                    poMobile.updateObject("sMobileID", lsMobileID);
+                                    poMobile.updateObject("cSubscrbr", CommonUtils.classifyNetwork((String)getMobile(lnCtr, "sMobileNo")));
+                                    poMobile.updateString("sEntryByx", poGRider.getUserID());
+                                    poMobile.updateObject("dEntryDte", (Date) poGRider.getServerDate());
+                                    poMobile.updateString("sModified", poGRider.getUserID());
+                                    poMobile.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    poMobile.updateRow();
 
-                                lsSQL = MiscUtil.rowset2SQL(poMobile, MOBILE_MASTER, "");
+                                    lsSQL = MiscUtil.rowset2SQL(poMobile, MOBILE_MASTER, "");
 
-                                if (poGRider.executeQuery(lsSQL, MOBILE_MASTER, psBranchCd, lsMobileID.substring(0, 4)) <= 0){
-                                    if (!pbWithParent) poGRider.rollbackTrans();
-                                    psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
-                                    return false;
-                                }
-                            }else{//if user modified already saved address                
-                                poMobile.updateObject("cSubscrbr", CommonUtils.classifyNetwork((String)getMobile(lnCtr, "sMobileNo")));
-                                poMobile.updateString("sModified", poGRider.getUserID());
-                                poMobile.updateObject("dModified", (Date) poGRider.getServerDate());
-                                lsSQL = MiscUtil.rowset2SQL(poMobile, 
-                                                            MOBILE_MASTER, 
-                                                            "", 
-                                                            "sMobileID = " + SQLUtil.toSQL(lsMobileID) +
-                                                            " AND sClientID = " + SQLUtil.toSQL((String) getMobile(lnCtr,"sClientID")));
-
-                                if (!lsSQL.isEmpty()){
                                     if (poGRider.executeQuery(lsSQL, MOBILE_MASTER, psBranchCd, lsMobileID.substring(0, 4)) <= 0){
                                         if (!pbWithParent) poGRider.rollbackTrans();
-                                        psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                        psMessage = poGRider.getMessage() + " ; " + poGRider.getErrMsg();
                                         return false;
+                                    }
+                                }else{//if user modified already saved address                
+                                    poMobile.updateObject("cSubscrbr", CommonUtils.classifyNetwork((String)getMobile(lnCtr, "sMobileNo")));
+                                    poMobile.updateString("sModified", poGRider.getUserID());
+                                    poMobile.updateObject("dModified", (Date) poGRider.getServerDate());
+                                    lsSQL = MiscUtil.rowset2SQL(poMobile, 
+                                                                MOBILE_MASTER, 
+                                                                "", 
+                                                                "sMobileID = " + SQLUtil.toSQL(lsMobileID) +
+                                                                " AND sClientID = " + SQLUtil.toSQL((String) getMobile(lnCtr,"sClientID")));
+
+                                    if (!lsSQL.isEmpty()){
+                                        if (poGRider.executeQuery(lsSQL, MOBILE_MASTER, psBranchCd, lsMobileID.substring(0, 4)) <= 0){
+                                            if (!pbWithParent) poGRider.rollbackTrans();
+                                            psMessage = poGRider.getMessage() + ";" + poGRider.getErrMsg();
+                                            return false;
+                                        }
                                     }
                                 }
                             }
@@ -309,7 +311,7 @@ public class ClientMobile {
                         }
                         // Update the original state of the table
                         poOriginalMobile = (CachedRowSet) poMobile.createCopy();
-                    }
+                    //}
                 }            
                 
                 if (!pbWithParent) poGRider.commitTrans();

--- a/src/org/rmj/auto/clients/base/ClientSocMed.java
+++ b/src/org/rmj/auto/clients/base/ClientSocMed.java
@@ -202,7 +202,7 @@ public class ClientSocMed {
             return false;
         }
         
-        boolean isModified = false;
+        //boolean isModified = false;
                           
         try {
             //dont save if no item
@@ -213,7 +213,7 @@ public class ClientSocMed {
                 int lnCtr;
 
                 if (pnEditMode == EditMode.ADDNEW){ //add
-                    isModified = true;
+                    //isModified = true;
                     lnCtr = 1;
                     poSocMed.beforeFirst();
                     while (poSocMed.next()){
@@ -243,20 +243,21 @@ public class ClientSocMed {
                     if (!pbWithParent) poGRider.beginTrans();
 
                     //check if changes has been made                
-                    lnCtr = 1;
-                    while (lnCtr <= getItemCount()){
-                        if (!CompareRows.isRowEqual(poSocMed, poOriginalSocMed)) {
-                            isModified = true;
-                            break;
-                        }
-                        lnCtr++;
-                    }
+//                    lnCtr = 1;
+//                    while (lnCtr <= getItemCount()){
+//                        if (!CompareRows.isRowEqual(poSocMed, poOriginalSocMed)) {
+//                            isModified = true;
+//                            break;
+//                        }
+//                        lnCtr++;
+//                    }
 
-                    if (isModified) {
-                        lnCtr = 1;
-                        poSocMed.beforeFirst();
-        //                while (poSocMed.next()){
-                        while (lnCtr <= getItemCount()){
+                    //if (isModified) {
+                    lnCtr = 1;
+                    poSocMed.beforeFirst();
+    //                while (poSocMed.next()){
+                    while (lnCtr <= getItemCount()){
+                        if(!CompareRows.isRowEqual(poSocMed, poOriginalSocMed,lnCtr)) {
                             String lsSocialID = (String) getSocMed(lnCtr, "sSocialID");
                             if (lsSocialID.equals("") || lsSocialID.isEmpty()){// check if user added new socmed to insert
                                 lsSocialID = MiscUtil.getNextCode(SOCMED_TABLE, "sSocialID", true, poGRider.getConnection(), psBranchCd);                            
@@ -294,11 +295,12 @@ public class ClientSocMed {
                                     }
                                 }
                             }
-                        lnCtr++;
                         }
+                    lnCtr++;
+                    }
                     // Update the original state of the table
                     poOriginalSocMed = (CachedRowSet) poSocMed.createCopy();
-                    }
+                    //}
                 }
 
 //                if (lsSQL.isEmpty()){

--- a/src/org/rmj/auto/clients/base/CompareRows.java
+++ b/src/org/rmj/auto/clients/base/CompareRows.java
@@ -14,24 +14,58 @@ import javax.sql.rowset.CachedRowSet;
  * @author User
  */
 public class CompareRows {    
-    public static boolean isRowEqual(CachedRowSet row1, CachedRowSet row2) throws SQLException{
-        if(row1 != null && row2 != null){
-            row1.beforeFirst();
-            row2.beforeFirst();
-            while (row1.next() && row2.next()) {
-                int columnCount = row1.getMetaData().getColumnCount();
-                for (int i = 1; i <= columnCount; i++) {
-                    Object value1 = row1.getObject(i);
-                    Object value2 = row2.getObject(i);
-                    if (!Objects.equals(value1, value2)) {
-                        return false;
-                    }
+    public static boolean isRowEqual(CachedRowSet row1, CachedRowSet row2, int rowNum) throws SQLException{
+        if (row1 != null && row2 != null) {
+            int row1Count = row1.size();
+            int row2Count = row2.size();
+
+            if (rowNum > row1Count || rowNum > row2Count) {
+                // The specified row number is greater than the number of rows in one of the cached row sets
+                return false;
+            }
+
+            row1.absolute(rowNum);
+            row2.absolute(rowNum);
+
+            int columnCount = row1.getMetaData().getColumnCount();
+
+            for (int i = 1; i <= columnCount; i++) {
+                Object value1 = row1.getObject(i);
+                Object value2 = row2.getObject(i);
+                if (!Objects.equals(value1, value2)) {
+                    return false;
                 }
             }
-        }else{
+
+            return true;
+        } else {
             return false;
         }
-    return true;          
     }
-    
 }
+//        if(row1 != null && row2 != null){
+//            row1.beforeFirst();
+//            row2.beforeFirst();
+//            while (row1.next() || row2.next()) {
+//                int columnCount = row1.getMetaData().getColumnCount();
+//                
+//                if (row1.getRow() != row2.getRow()) {
+//                    // Rows don't match
+//                    return false;
+//                }
+//                
+//                for (int i = 1; i <= columnCount; i++) {
+//                    Object value1 = row1.getObject(i);
+//                    Object value2 = row2.getObject(i);
+//                    if (!Objects.equals(value1, value2)) {
+//                        return false;
+//                    }
+//                }
+//            }
+//        }else{
+//            return false;
+//        }
+//    return true;          
+//    }
+    
+//}

--- a/src/org/rmj/auto/clients/base/VehicleDescription.java
+++ b/src/org/rmj/auto/clients/base/VehicleDescription.java
@@ -112,7 +112,7 @@ public class VehicleDescription {
         return poVehicle.getObject(fnIndex);
     }
     
-     public Object getDetail(int fnRow, int fnIndex) throws SQLException{
+    public Object getDetail(int fnRow, int fnIndex) throws SQLException{
         if (fnIndex == 0) return null;
         
         poVehicle.absolute(fnRow);

--- a/src/org/rmj/auto/parameters/CancellationMaster.java
+++ b/src/org/rmj/auto/parameters/CancellationMaster.java
@@ -8,6 +8,7 @@ package org.rmj.auto.parameters;
 import org.rmj.appdriver.GRider;
 import org.rmj.appdriver.MiscUtil;
 import org.rmj.appdriver.SQLUtil;
+import org.rmj.appdriver.callback.MasterCallback;
 import org.rmj.appdriver.constants.EditMode;
 
 /**
@@ -16,9 +17,28 @@ import org.rmj.appdriver.constants.EditMode;
  */
 public class CancellationMaster {
     private GRider poGRider;
-    private String psBranchCd = poGRider.getBranchCode();
+    private String psBranchCd;
     public String psMessage;
     private int pnEditMode;
+    private boolean pbWithParent;
+    private MasterCallback poCallback;
+       
+    private boolean pbWithUI;
+
+    public CancellationMaster(GRider foGRider, String fsBranchCd, boolean fbWithParent){            
+        
+        poGRider = foGRider;
+        psBranchCd = fsBranchCd;
+        pbWithParent = fbWithParent;                       
+    }    
+    
+    public void setWithUI(boolean fbValue){
+        pbWithUI = fbValue;
+    }
+    
+    public void setCallback(MasterCallback foValue){
+        poCallback = foValue;
+    }
     
     public int getEditMode(){
         return pnEditMode;
@@ -32,10 +52,10 @@ public class CancellationMaster {
         String lsSQL ="INSERT INTO cancellation_Master SET" +
                         " sTransNox = " + SQLUtil.toSQL(MiscUtil.getNextCode("cancellation_master", "sTransNox", true, poGRider.getConnection(), psBranchCd)) +
                         " ,dTransact = " + SQLUtil.toSQL(poGRider.getServerDate()) + 
-                        " ,sRemarks = " + SQLUtil.toSQL(fsRemarks) +
+                        " ,sRemarksx = " + SQLUtil.toSQL(fsRemarks) +
                         " ,sReferNox = " + SQLUtil.toSQL(fsReferNox) +
                         " ,sSourceCD = " + SQLUtil.toSQL(fsSourceCD) +
-                        " ,sSourceNo = " + SQLUtil.toSQL(fsSourceNo) +
+                        " ,sSourceNo = " + SQLUtil.toSQL(fsSourceNo) +                        
                         " ,sEntryByx = " + SQLUtil.toSQL(poGRider.getUserID()) +
                         " ,dEntryDte = " + SQLUtil.toSQL(poGRider.getServerDate());
         

--- a/test/testActivity.java
+++ b/test/testActivity.java
@@ -1,0 +1,271 @@
+
+import java.sql.SQLException;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.rmj.appdriver.GRider;
+import org.rmj.appdriver.callback.MasterCallback;
+import org.rmj.auto.clients.base.Activity;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ *
+ * @author User
+ */
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class testActivity {
+    static GRider instance = new GRider();
+    static Activity trans;
+    static MasterCallback callback;
+    
+    public testActivity(){}
+    
+    @BeforeClass
+    public static void setUpClass() {   
+        String path;
+        if(System.getProperty("os.name").toLowerCase().contains("win")){
+            path = "D:/GGC_Java_Systems";
+        }
+        else{
+            path = "/srv/GGC_Java_Systems";
+        }
+        System.setProperty("sys.default.path.config", path);
+        
+        if (!instance.logUser("AutoApp", "M001111122")){
+            System.err.println(instance.getMessage() + instance.getErrMsg());
+            System.exit(1);
+        }
+        
+        callback = new MasterCallback() {
+            @Override
+            public void onSuccess(int fnIndex, Object foValue) {
+                System.out.println(fnIndex + "-->>" + foValue);
+            }
+        };
+        
+        trans = new Activity(instance, instance.getBranchCode(), false);
+        trans.setWithUI(true);
+        trans.setCallback(callback);
+        
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Test
+    public void test01NewRecord() throws SQLException{
+        // Call the method under test
+        boolean result = trans.NewRecord();
+        //trans.displayMemberFields();
+        trans.displayMasFields();
+        trans.setMaster("sActTitle", "testtitle");
+        trans.setMaster("sActDescx", "testdesc");
+        trans.setMaster("sActTypID", "tes");
+        trans.setMaster("sActSrcex", "testsource");
+        trans.setMaster("sLocation", "tes");
+        trans.setMaster("sCompnynx", "testestablishment");
+        trans.setMaster("sLogRemrk", "testlogremarks");
+        trans.setMaster("sRemarksx", "testremarks");
+        trans.searchEmployee("arcilla");
+        trans.searchDepartment("mis");
+        trans.searchProvince("Pangasinan");
+        // Verify the expected behavior and assertions
+        assertTrue(result); // Assert that the method returns true
+        //assertEquals(0, trans.poActMember.size()); 
+    }
+    
+    @Test
+    public void test02LoadEmployee() throws SQLException{
+        trans.loadEmployee("A010",true);
+        // Print the column names
+        for (int i = 1; i <= trans.poEmployees.getMetaData().getColumnCount(); i++) {
+            System.out.print(trans.poEmployees.getMetaData().getColumnName(i) + "\t");
+        }
+        System.out.println();
+
+        // Print the data rows
+        while (trans.poEmployees.next()) {
+            for (int i = 1; i <= trans.poEmployees.getMetaData().getColumnCount(); i++) {
+                System.out.print(trans.poEmployees.getString(i) + "\t");
+            }
+            System.out.println();
+        }
+    }
+    
+    @Test
+    public void test03LoadDepartment() throws SQLException{
+        trans.loadDepartment();
+        // Print the column names
+        for (int i = 1; i <= trans.poDepartment.getMetaData().getColumnCount(); i++) {
+            System.out.print(trans.poDepartment.getMetaData().getColumnName(i) + "\t");
+        }
+        System.out.println();
+
+        // Print the data rows
+        while (trans.poDepartment.next()) {
+            for (int i = 1; i <= trans.poDepartment.getMetaData().getColumnCount(); i++) {
+                System.out.print(trans.poDepartment.getString(i) + "\t");
+            }
+            System.out.println();
+        }
+    }
+    
+    @Test
+    public void test05searchDepartment() throws SQLException{
+        boolean result = trans.searchDepartment("mis");
+
+        // Verify the expected behavior and assertions
+        assertTrue(result); // Assert that the method returns true
+        // Assert any other expected behavior or assertions based on the mocked values
+    }
+    
+    @Test
+    public void test06searchEmployee() throws SQLException{
+        
+        boolean result = trans.searchEmployee("Arcilla");
+        assertTrue(result);
+    }
+    
+    @Test
+    public void test07AddMember() throws SQLException {
+        // Call the method under test
+        boolean result = trans.addMember("A00118000198", "Arcilla, Jahn Randolph Bron", "MIS");
+        result = trans.addMember("A00118000199", "Arcilla, Jahn Randolph Bron", "PARTS");
+        
+        // Verify the expected behavior and assertions
+        //assertTrue(result); // Assert that the method returns true
+        // Assert any other expected behavior or assertions based on the mocked values
+        
+        // Print the column names
+        for (int i = 1; i <= trans.poActMember.getMetaData().getColumnCount(); i++) {
+            System.out.print(trans.poActMember.getMetaData().getColumnName(i) + "\t");
+        }
+        System.out.println();
+
+        // Print the data rows
+        while (trans.poActMember.next()) {
+            for (int i = 1; i <= trans.poActMember.getMetaData().getColumnCount(); i++) {
+                System.out.print(trans.poActMember.getString(i) + "\t");
+            }
+            System.out.println();
+        }
+    }
+    
+    @Test
+    public void test08searchProvince() throws SQLException{
+        boolean result = trans.searchProvince("Pangasinan");
+        assertTrue(result);
+        
+    }
+    
+    @Test
+    public void test09loadTown() throws SQLException{
+        boolean result = trans.loadTown("01",true);
+    }
+    
+    @Test
+    public void test10LoadAndAddTown() throws SQLException {
+        String testProvince = "01"; // Replace with the desired test province
+        String testTownID = "0314"; // Replace with the desired test town ID
+        String testTownName = "Test Town"; // Replace with the desired test town name
+        String testTownID2 = "0315"; // Replace with the desired test town ID
+        String testTownName2 = "Lingayen"; // Replace with the desired test town name
+        String testTownID3 = "0318"; // Replace with the desired test town ID
+        String testTownName3 = "Alaminos City"; // Replace with the desired test town name
+        
+        // Load town
+       // boolean loadResult = trans.loadTown(testProvince,true);
+        //assertTrue("The town should be loaded successfully", loadResult);
+        
+        // Add town
+       // boolean addResult = 
+        trans.addActTown(testTownID, testTownName);
+        trans.addActTown(testTownID2, testTownName2);
+        trans.addActTown(testTownID3, testTownName3);
+        //assertTrue("The town should be added successfully", addResult);
+        
+         //Print the column names
+        for (int i = 1; i <= trans.poActTown.getMetaData().getColumnCount(); i++) {
+            System.out.print(trans.poActTown.getMetaData().getColumnName(i) + "\t");
+        }
+        System.out.println();
+
+        // Print the data rows
+        while (trans.poActTown.next()) {
+            for (int i = 1; i <= trans.poActTown.getMetaData().getColumnCount(); i++) {
+                System.out.print(trans.poActTown.getString(i) + "\t");
+            }
+            System.out.println();
+        }
+        
+    }
+//    @Test
+//    public void test11LoadVehicle() throws SQLException{
+//        boolean result = trans.loadActVehicle("", false);
+//        assertTrue(result);
+//        
+//        for (int i = 1; i <= trans.poVehicle.getMetaData().getColumnCount(); i++) {
+//            System.out.print(trans.poVehicle.getMetaData().getColumnName(i) + "\t");
+//        }
+//        System.out.println();
+//
+//        // Print the data rows
+//        while (trans.poVehicle.next()) {
+//            for (int i = 1; i <= trans.poVehicle.getMetaData().getColumnCount(); i++) {
+//                System.out.print(trans.poVehicle.getString(i) + "\t");
+//            }
+//            System.out.println();
+//        }
+//    }
+    
+    @Test
+    public void test12AddVehicle() throws SQLException{
+        String fsDescript = "HONDA HATCHBACK 1.4L AT BLUE 2023" ;
+        String fsSerialID = "V00123000001"   ;  
+        String fsCSNOxxxx = "EA5555"   ;  
+        boolean result = trans.addActVehicle(fsSerialID,fsDescript,fsCSNOxxxx);
+        //trans.addActVehicle(fsDescript, fsSerialID,fsCSNOxxxx);
+        assertTrue(result);
+        for (int i = 1; i <= trans.poActVehicle.getMetaData().getColumnCount(); i++) {
+            System.out.print(trans.poActVehicle.getMetaData().getColumnName(i) + "\t");
+        }
+        System.out.println();
+
+        // Print the data rows
+        while (trans.poActVehicle.next()) {
+            for (int i = 1; i <= trans.poActVehicle.getMetaData().getColumnCount(); i++) {
+                System.out.print(trans.poActVehicle.getString(i) + "\t");
+            }
+            System.out.println();
+        }       
+    }
+//    
+//    @Test
+//    public void test13SearchRecord() throws SQLException{
+//        boolean result = trans.SearchRecord("1", true);
+//        assertTrue(result);
+//    }
+//    
+    @Test
+    public void test13SearchBranch() throws SQLException{
+         trans.searchBranch("MCC LUC");
+    }
+    
+    @Test
+    public void test14SaveRecord(){
+        boolean result = trans.SaveRecord();
+        assertTrue(result);
+    }    
+    
+}


### PR DESCRIPTION
Fix loading of address need to reset when new client loads
added loadDepartment
added loadEmployee
added addMember
added removeActMember
create getter/setter for master data
create getter/setter for Activity Member Data
create getter/setter for Activity Department Data
create getSQ_Master() function for master query
create getSQ_Department() function for Department query
create getSQ_Employee() function for Employee query
create getSQ_ActMember() function for activity member query
Added NewRecord()
Added SearchRecord()
Added OpenRecord
Refactor getSQ_Master
Added searchDepartment
Created getSQ_Vehicle() query for activity Vehicle
Created getSQ_ActVehicle query for activity Vehicle
added searchEmployee
Added loadTown
Added searchProvince
-added getSQ_ActivityTown
-added getters and setters for activity town
-added addTown
-added SaveRecord
-modified setMaster and getSQ_master removed sTownIDxx and sAddressx
-added removeTown
-fixed saving when editing
-added getbranch not yet done
Modified searching of Town only search towns based on province selected
Created getSQ_Branch() query for getting branches
added searchBranch() retrieval of branch based on logged location
create getter/setter for activity Vehicle data
added loadActVehicle
added addActVehicle
create getter/setter for activity employee
added cancelActivity
added removeactVehicle
modified loadTown fixed loading when called for loading activity Town
create getter/setter for town
create getter/setter for activity employee
added cancelActivity
added removeactVehicle
modified loadTown fixed loading when called for loading activity Town
create getter/setter for town
added SaveEventType -Saves an event type to the database
added searchEventType-Searches for an event type based on the provided value
added ApproveActivity-Approves an activity with the specified value.
refactor setMaster- added sEventTyp in getSQ_master
Modified all searching fixed error with searching criteria
fixed searchBranch
