### PR TITLE
Bug Fixes: Client Vehicle Info and Vehicle Description Parameter Class

### DIFF
--- a/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
+++ b/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
@@ -44,6 +44,7 @@ public class ClientVehicleInfo {
     private String psClientID;
     
     private CachedRowSet poVehicle;
+    private CachedRowSet poVehicleDetail;
     private CachedRowSet poOriginalVehicle;
     
     public ClientVehicleInfo(GRider foGRider, String fsBranchCd, boolean fbWithParent){            
@@ -96,10 +97,8 @@ public class ClientVehicleInfo {
             case 13:
             case 14:
             case 15:
-            case 16:
-            case 18:
             case 20:
-            case 22:
+            case 21:
             case 23:
             case 24:
             case 25:
@@ -110,13 +109,12 @@ public class ClientVehicleInfo {
             case 30:
             case 31:
             case 32:
+            case 35:
                 poVehicle.updateObject(fnIndex, (String) foValue);
                 poVehicle.updateRow();
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
                 break;
-            case 17:
-            case 19:
-            case 21:
+            case 22:
                 if (foValue instanceof Date){
                     poVehicle.updateObject(fnIndex, foValue);
                 } else {
@@ -211,8 +209,8 @@ public class ClientVehicleInfo {
         //open master
         lsSQL =  MiscUtil.addCondition(getSQ_Master(), "sClientID = " + SQLUtil.toSQL(fsValue));
         loRS = poGRider.executeQuery(lsSQL);
-        poVehicle = factory.createCachedRowSet();
-        poVehicle.populate(loRS);
+        poVehicleDetail = factory.createCachedRowSet();
+        poVehicleDetail.populate(loRS);
         MiscUtil.close(loRS);
         
         return true;
@@ -310,7 +308,7 @@ public class ClientVehicleInfo {
                 
             } else { //update
                 while (lnCtr <= getItemCount()){
-                    if (!CompareRows.isRowEqual(poVehicle, poOriginalVehicle)) {
+                    if (!CompareRows.isRowEqual(poVehicle, poOriginalVehicle,lnCtr)) {
                         lbisModified = true;
                         break;
                     }
@@ -408,39 +406,40 @@ public class ClientVehicleInfo {
     
     private String getSQ_Master(){
         return  "SELECT" + //
-                "   IFNULL(a.sSerialID,'') sSerialID " + //
-                " , IFNULL(a.sBranchCD,'') sBranchCD " + //
-                " , IFNULL(a.sFrameNox,'') sFrameNox " + //
-                " , IFNULL(a.sEngineNo,'') sEngineNo " + //
-                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx " + //
-                " , IFNULL(a.sClientID,'') sClientID " + //
-                " , IFNULL(a.sCoCltIDx,'') sCoCltIDx " + //
-                " , IFNULL(a.sCSNoxxxx,'') sCSNoxxxx " + //
-                " , IFNULL(a.sDealerNm,'') sDealerNm " + //
-                " , IFNULL(a.sCompnyID,'') sCompnyID " + //
-                " , IFNULL(a.sKeyNoxxx,'') sKeyNoxxx " + //
-                " , IFNULL(a.cIsDemoxx,'') cIsDemoxx " + //
-                " , IFNULL(a.cLocation,'') cLocation " + //
-                " , IFNULL(a.cSoldStat,'') cSoldStat " + //
-                " , IFNULL(a.cVhclNewx,'') cVhclNewx " + //
-                " , a.sEntryByx " + //
-                " , a.dEntryDte " + //
-                " , a.sModified " + //
-                " , a.dModified " + //
-                " , IFNULL(b.sPlateNox,'') sPlateNox " + //
-                " , b.dRegister " + //
-                " , IFNULL(b.sPlaceReg,'') sPlaceReg " + //   
-                " , IFNULL(c.sMakeIDxx,'') sMakeIDxx " + // 
-                " , IFNULL(d.sMakeDesc,'') sMakeDesc " + //   
-                " , IFNULL(c.sModelIDx,'') sModelIDx " + //  
-                " , IFNULL(e.sModelDsc,'') sModelDsc " + //   
-                " , IFNULL(c.sTypeIDxx,'') sTypeIDxx " + // 
-                " , IFNULL(f.sTypeDesc,'') sTypeDesc " + //   
-                " , IFNULL(c.sColorIDx,'') sColorIDx " + // 
-                " , IFNULL(g.sColorDsc,'') sColorDsc " + //
-                " , IFNULL(c.sTransMsn,'') sTransMsn " + //
-                " , IFNULL(c.nYearModl,'') nYearModl " + //
-                " , IFNULL(c.sDescript,'') sDescript " + //
+                "   IFNULL(a.sSerialID,'') sSerialID " + //1
+                " , IFNULL(a.sBranchCD,'') sBranchCD " + //2
+                " , IFNULL(a.sFrameNox,'') sFrameNox " + //3
+                " , IFNULL(a.sEngineNo,'') sEngineNo " + //4
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx " + //5
+                " , IFNULL(a.sClientID,'') sClientID " + //6
+                " , IFNULL(a.sCoCltIDx,'') sCoCltIDx " + //7
+                " , IFNULL(a.sCSNoxxxx,'') sCSNoxxxx " + //8
+                " , IFNULL(a.sDealerNm,'') sDealerNm " + //9
+                " , IFNULL(a.sCompnyID,'') sCompnyID " + //10
+                " , IFNULL(a.sKeyNoxxx,'') sKeyNoxxx " + //12
+                " , IFNULL(a.cIsDemoxx,'') cIsDemoxx " + //13
+                " , IFNULL(a.cLocation,'') cLocation " + //14
+                " , IFNULL(a.cSoldStat,'') cSoldStat " + //15
+                " , IFNULL(a.cVhclNewx,'') cVhclNewx " + //16
+                " , a.sEntryByx " + //17
+                " , a.dEntryDte " + //18
+                " , a.sModified " + //19
+                " , a.dModified " + //20
+                " , IFNULL(b.sPlateNox,'') sPlateNox " + //21
+                " , b.dRegister " + //22
+                " , IFNULL(b.sPlaceReg,'') sPlaceReg " + //23
+                " , IFNULL(c.sMakeIDxx,'') sMakeIDxx " + //24
+                " , IFNULL(d.sMakeDesc,'') sMakeDesc " + //25 
+                " , IFNULL(c.sModelIDx,'') sModelIDx " + //26
+                " , IFNULL(e.sModelDsc,'') sModelDsc " + //27   
+                " , IFNULL(c.sTypeIDxx,'') sTypeIDxx " + //28 
+                " , IFNULL(f.sTypeDesc,'') sTypeDesc " + //29   
+                " , IFNULL(c.sColorIDx,'') sColorIDx " + //30 
+                " , IFNULL(g.sColorDsc,'') sColorDsc " + //31
+                " , IFNULL(c.sTransMsn,'') sTransMsn " + //32
+                " , IFNULL(c.nYearModl,'') nYearModl " + //33
+                " , IFNULL(c.sDescript,'') sDescript " + //34
+                " , IFNULL(a.sRemarksx,'') sRemarksx " + //35
                 "   FROM vehicle_serial a " + 
                 "   LEFT JOIN vehicle_serial_registration b ON a.sSerialID = b.sSerialID  " +
                 "   LEFT JOIN vehicle_master c ON c.sVhclIDxx = a.sVhclIDxx  " +
@@ -507,8 +506,9 @@ public class ClientVehicleInfo {
     public boolean searchAvailableVhcl() throws SQLException{
         String lsSQL = getSQ_Master();
         
-        lsSQL = MiscUtil.addCondition(lsSQL, " a.cSoldStat = '1' AND (ISNULL(a.sClientID) OR  TRIM(a.sClientID) <> '' " );
+        lsSQL = MiscUtil.addCondition(lsSQL, " a.cSoldStat = '1' AND (ISNULL(a.sClientID) OR  TRIM(a.sClientID) <> '' )" );
         
+        System.out.println(lsSQL);
         ResultSet loRS;
         loRS = poGRider.executeQuery(lsSQL);
         JSONObject loJSON = showFXDialog.jsonSearch(poGRider

--- a/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
+++ b/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
@@ -70,8 +70,8 @@ public class ClientVehicleInfo {
     }
     
     public int getItemCount() throws SQLException{
-        poVehicle.last();
-        return poVehicle.getRow();
+        poVehicleDetail.last();
+        return poVehicleDetail.getRow();
     }
     
     public void setClientID(String fsValue) {
@@ -98,7 +98,7 @@ public class ClientVehicleInfo {
             case 14:
             case 15:
             case 20:
-            case 21:
+            case 22:
             case 23:
             case 24:
             case 25:
@@ -109,12 +109,13 @@ public class ClientVehicleInfo {
             case 30:
             case 31:
             case 32:
-            case 35:
+            case 33:
+            case 34:
                 poVehicle.updateObject(fnIndex, (String) foValue);
                 poVehicle.updateRow();
                 if (poCallback != null) poCallback.onSuccess(fnIndex, getMaster(fnIndex));
                 break;
-            case 22:
+            case 21:
                 if (foValue instanceof Date){
                     poVehicle.updateObject(fnIndex, foValue);
                 } else {
@@ -143,12 +144,12 @@ public class ClientVehicleInfo {
     public Object getDetail(int fnRow, int fnIndex) throws SQLException{
         if (fnIndex == 0) return null;
         
-        poVehicle.absolute(fnRow);
-        return poVehicle.getObject(fnIndex);
+        poVehicleDetail.absolute(fnRow);
+        return poVehicleDetail.getObject(fnIndex);
     }
     
     public Object getDetail(int fnRow, String fsIndex) throws SQLException{
-        return getDetail(fnRow, MiscUtil.getColumnIndex(poVehicle, fsIndex));
+        return getDetail(fnRow, MiscUtil.getColumnIndex(poVehicleDetail, fsIndex));
     }
     
     /**
@@ -176,7 +177,7 @@ public class ClientVehicleInfo {
             poVehicle.moveToInsertRow();
             
             MiscUtil.initRowSet(poVehicle);       
-            //poVehicle.updateString("cRecdStat", RecordStatus.ACTIVE);    
+            poVehicle.updateObject("dRegister", SQLUtil.toDate(DEFAULT_DATE, SQLUtil.FORMAT_SHORT_DATE));    
             poVehicle.insertRow();
             poVehicle.moveToCurrentRow();                        
             
@@ -222,12 +223,12 @@ public class ClientVehicleInfo {
      * @return {@code true} if the record is successfully opened, {@code false} otherwise.
     */
     public boolean OpenRecord(String fsValue){
-        if (poVehicle == null){
+        if (poVehicleDetail == null){
             psMessage = "Application driver is not set.";
             return false;
         }
         try {
-            String lsSQL = MiscUtil.addCondition(getSQ_Master(), "sSerialID = " + SQLUtil.toSQL(fsValue));
+            String lsSQL = MiscUtil.addCondition(getSQ_Master(), "a.sSerialID = " + SQLUtil.toSQL(fsValue));
             ResultSet loRS = poGRider.executeQuery(lsSQL);
             
             if (MiscUtil.RecordCount(loRS) <= 0){
@@ -314,9 +315,8 @@ public class ClientVehicleInfo {
                     }
                     lnCtr++;
                 }
-                
+                psSerialID = (String) getMaster("sSerialID") ;
                 if(lbisModified){
-                    psSerialID = (String) getMaster("sSerialID") ; 
                     poVehicle.updateString("sClientID", psClientID);
                     poVehicle.updateString("sModified", poGRider.getUserID());
                     poVehicle.updateObject("dModified", (Date) poGRider.getServerDate());
@@ -369,8 +369,8 @@ public class ClientVehicleInfo {
                         return false;
                     }           
                 } else { //update  
-                    if(lsPlateNox.equals((String) poOriginalVehicle.getObject("sPlateNox")) || ldDateRegs.equals((Date) poOriginalVehicle.getObject("dRegister")) || lsPlcRegs.equals((String) poOriginalVehicle.getObject("sPlaceReg"))) {
-                    } else {
+//                    if(lsPlateNox.equals((String) poOriginalVehicle.getObject("sPlateNox")) || ldDateRegs.equals((Date) poOriginalVehicle.getObject("dRegister")) || lsPlcRegs.equals((String) poOriginalVehicle.getObject("sPlaceReg"))) {
+//                    } else {
                         lsSQL = "UPDATE vehicle_serial_registration SET" +
                                 "  sPlateNox = " + SQLUtil.toSQL(lsPlateNox) +
                                 ", dRegister = " + SQLUtil.toSQL(ldDateRegs) +
@@ -387,7 +387,7 @@ public class ClientVehicleInfo {
                             psMessage = poGRider.getErrMsg() + "; " + poGRider.getMessage();
                             return false;
                         }      
-                    }
+//                    }
                 }
             }
             
@@ -401,6 +401,7 @@ public class ClientVehicleInfo {
         }
         
         pnEditMode = EditMode.UNKNOWN;
+        psMessage = "Vehicle saved Successfully";
         return true;
     }
     
@@ -416,30 +417,30 @@ public class ClientVehicleInfo {
                 " , IFNULL(a.sCSNoxxxx,'') sCSNoxxxx " + //8
                 " , IFNULL(a.sDealerNm,'') sDealerNm " + //9
                 " , IFNULL(a.sCompnyID,'') sCompnyID " + //10
-                " , IFNULL(a.sKeyNoxxx,'') sKeyNoxxx " + //12
-                " , IFNULL(a.cIsDemoxx,'') cIsDemoxx " + //13
-                " , IFNULL(a.cLocation,'') cLocation " + //14
-                " , IFNULL(a.cSoldStat,'') cSoldStat " + //15
-                " , IFNULL(a.cVhclNewx,'') cVhclNewx " + //16
-                " , a.sEntryByx " + //17
-                " , a.dEntryDte " + //18
-                " , a.sModified " + //19
-                " , a.dModified " + //20
-                " , IFNULL(b.sPlateNox,'') sPlateNox " + //21
-                " , b.dRegister " + //22
-                " , IFNULL(b.sPlaceReg,'') sPlaceReg " + //23
-                " , IFNULL(c.sMakeIDxx,'') sMakeIDxx " + //24
-                " , IFNULL(d.sMakeDesc,'') sMakeDesc " + //25 
-                " , IFNULL(c.sModelIDx,'') sModelIDx " + //26
-                " , IFNULL(e.sModelDsc,'') sModelDsc " + //27   
-                " , IFNULL(c.sTypeIDxx,'') sTypeIDxx " + //28 
-                " , IFNULL(f.sTypeDesc,'') sTypeDesc " + //29   
-                " , IFNULL(c.sColorIDx,'') sColorIDx " + //30 
-                " , IFNULL(g.sColorDsc,'') sColorDsc " + //31
-                " , IFNULL(c.sTransMsn,'') sTransMsn " + //32
-                " , IFNULL(c.nYearModl,'') nYearModl " + //33
-                " , IFNULL(c.sDescript,'') sDescript " + //34
-                " , IFNULL(a.sRemarksx,'') sRemarksx " + //35
+                " , IFNULL(a.sKeyNoxxx,'') sKeyNoxxx " + //11
+                " , IFNULL(a.cIsDemoxx,'') cIsDemoxx " + //12
+                " , IFNULL(a.cLocation,'') cLocation " + //13
+                " , IFNULL(a.cSoldStat,'') cSoldStat " + //14
+                " , IFNULL(a.cVhclNewx,'') cVhclNewx " + //15
+                " , a.sEntryByx " + //16
+                " , a.dEntryDte " + //17
+                " , a.sModified " + //18
+                " , a.dModified " + //19
+                " , IFNULL(b.sPlateNox,'') sPlateNox " + //20
+                " , b.dRegister " + //21
+                " , IFNULL(b.sPlaceReg,'') sPlaceReg " + //22
+                " , IFNULL(c.sMakeIDxx,'') sMakeIDxx " + //23
+                " , IFNULL(d.sMakeDesc,'') sMakeDesc " + //24 
+                " , IFNULL(c.sModelIDx,'') sModelIDx " + //25
+                " , IFNULL(e.sModelDsc,'') sModelDsc " + //26   
+                " , IFNULL(c.sTypeIDxx,'') sTypeIDxx " + //27 
+                " , IFNULL(f.sTypeDesc,'') sTypeDesc " + //28   
+                " , IFNULL(c.sColorIDx,'') sColorIDx " + //29 
+                " , IFNULL(g.sColorDsc,'') sColorDsc " + //30
+                " , IFNULL(c.sTransMsn,'') sTransMsn " + //31
+                " , IFNULL(c.nYearModl,'') nYearModl " + //32
+                " , IFNULL(c.sDescript,'') sDescript " + //33
+                " , IFNULL(a.sRemarksx,'') sRemarksx " + //34
                 "   FROM vehicle_serial a " + 
                 "   LEFT JOIN vehicle_serial_registration b ON a.sSerialID = b.sSerialID  " +
                 "   LEFT JOIN vehicle_master c ON c.sVhclIDxx = a.sVhclIDxx  " +
@@ -452,7 +453,8 @@ public class ClientVehicleInfo {
     private String getSQ_SearchVhclMake(){
         return  " SELECT " +  
                 " IFNULL(a.sMakeIDxx,'') sMakeIDxx  " +   
-                " , IFNULL(b.sMakeDesc,'') sMakeDesc " +    
+                " , IFNULL(b.sMakeDesc,'') sMakeDesc " +   
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +   
                 " FROM vehicle_master a " + 
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx " ;
     }
@@ -460,7 +462,8 @@ public class ClientVehicleInfo {
     private String getSQ_SearchVhclModel(){
         return  " SELECT " +  
                 " IFNULL(a.sModelIDx,'') sModelIDx  " +   
-                " , IFNULL(b.sModelDsc,'') sModelDsc " +    
+                " , IFNULL(b.sModelDsc,'') sModelDsc " +  
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +    
                 " FROM vehicle_master a " + 
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " ;
     }
@@ -468,7 +471,8 @@ public class ClientVehicleInfo {
     private String getSQ_SearchVhclType(){
         return  " SELECT " +  
                 " IFNULL(a.sTypeIDxx,'') sTypeIDxx  " +   
-                " , IFNULL(b.sTypeDesc,'') sTypeDesc " +    
+                " , IFNULL(b.sTypeDesc,'') sTypeDesc " +  
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +    
                 " FROM vehicle_master a " + 
                 " LEFT JOIN vehicle_type b ON b.sTypeIDxx = a.sTypeIDxx " ;
     }
@@ -476,20 +480,23 @@ public class ClientVehicleInfo {
     private String getSQ_SearchVhclColor(){
         return  " SELECT " +  
                 " IFNULL(a.sColorIDx,'') sColorIDx  " +   
-                " , IFNULL(b.sColorDsc,'') sColorDsc " +    
+                " , IFNULL(b.sColorDsc,'') sColorDsc " +  
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +    
                 " FROM vehicle_master a " + 
                 " LEFT JOIN vehicle_color b ON b.sColorIDx = a.sColorIDx " ;
     }
     
     private String getSQ_SearchVhclTrnsMn(){
         return  " SELECT " +  
-                " IFNULL(a.sTransMsn,'') sTransMsn  " +     
+                " IFNULL(a.sTransMsn,'') sTransMsn  " +    
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +   
                 " FROM vehicle_master a";
     }
     
     private String getSQ_SearchVhclYearMdl(){
         return  " SELECT " +  
-                " IFNULL(a.nYearModl,'') nYearModl  " +     
+                " IFNULL(a.nYearModl,'') nYearModl  " +    
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +
                 " FROM vehicle_master a";
     }
     
@@ -537,7 +544,8 @@ public class ClientVehicleInfo {
     */
     public boolean searchVehicleMake(String fsValue) throws SQLException{
         String lsSQL = getSQ_SearchVhclMake();
-        
+        String lsOrigVal = getMaster(23).toString();
+        String lsNewVal = "";
         lsSQL = (MiscUtil.addCondition(lsSQL, " b.sMakeDesc LIKE " + SQLUtil.toSQL(fsValue + "%"))  +
                                                   " GROUP BY a.sMakeIDxx " );
         
@@ -547,6 +555,7 @@ public class ClientVehicleInfo {
             loRS = poGRider.executeQuery(lsSQL);
             
             if (loRS.next()){
+                lsNewVal = loRS.getString("sMakeIDxx");
                 setMaster("sMakeIDxx", loRS.getString("sMakeIDxx"));
                 setMaster("sMakeDesc", loRS.getString("sMakeDesc"));
             } else {
@@ -562,10 +571,23 @@ public class ClientVehicleInfo {
                 psMessage = "No record found/selected.";
                 return false;
             } else {
+                lsNewVal = (String) loJSON.get("sMakeIDxx");
                 setMaster("sMakeIDxx", (String) loJSON.get("sMakeIDxx"));
                 setMaster("sMakeDesc", (String) loJSON.get("sMakeDesc"));
             }
-        }        
+        }   
+            
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sVhclIDxx", "");
+            setMaster("sModelIDx", "");
+            setMaster("sModelDsc", "");
+            setMaster("sTypeIDxx", "");
+            setMaster("sTypeDesc", "");
+            setMaster("sColorIDx", "");
+            setMaster("sColorDsc", "");
+            setMaster("sTransMsn", "");
+            setMaster("nYearModl", "");
+        }     
         return true;
     }
     /**
@@ -575,7 +597,8 @@ public class ClientVehicleInfo {
     */
     public boolean searchVehicleModel(String fsValue) throws SQLException{
         String lsSQL = getSQ_SearchVhclModel();
-        
+        String lsOrigVal = getMaster(25).toString();
+        String lsNewVal = "";
         lsSQL = (MiscUtil.addCondition(lsSQL, " b.sModelDsc LIKE " + SQLUtil.toSQL(fsValue + "%") +
                                                   " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx"))
                                         )  +      " GROUP BY a.sModelIDx " );
@@ -586,6 +609,7 @@ public class ClientVehicleInfo {
             loRS = poGRider.executeQuery(lsSQL);
             
             if (loRS.next()){
+                lsNewVal = loRS.getString("sModelIDx");
                 setMaster("sModelIDx", loRS.getString("sModelIDx"));
                 setMaster("sModelDsc", loRS.getString("sModelDsc"));
             } else {
@@ -601,10 +625,21 @@ public class ClientVehicleInfo {
                 psMessage = "No record found/selected.";
                 return false;
             } else {
+                lsNewVal = (String) loJSON.get("sModelIDx");
                 setMaster("sModelIDx", (String) loJSON.get("sModelIDx"));
                 setMaster("sModelDsc", (String) loJSON.get("sModelDsc"));
             }
-        }        
+        } 
+            
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sVhclIDxx", "");
+            setMaster("sTypeIDxx", "");
+            setMaster("sTypeDesc", "");
+            setMaster("sColorIDx", "");
+            setMaster("sColorDsc", "");
+            setMaster("sTransMsn", "");
+            setMaster("nYearModl", "");
+        }       
         return true;
     }
     /**
@@ -614,7 +649,8 @@ public class ClientVehicleInfo {
     */
     public boolean searchVehicleType(String fsValue) throws SQLException{
         String lsSQL = getSQ_SearchVhclType();
-        
+        String lsOrigVal = getMaster(27).toString();
+        String lsNewVal = "";
         lsSQL = (MiscUtil.addCondition(lsSQL, " b.sTypeDesc LIKE " + SQLUtil.toSQL(fsValue + "%") +
                                                   " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx")) +
                                                   " AND a.sModelIDx = " + SQLUtil.toSQL((String) getMaster("sModelIDx"))
@@ -626,6 +662,7 @@ public class ClientVehicleInfo {
             loRS = poGRider.executeQuery(lsSQL);
             
             if (loRS.next()){
+                lsNewVal = loRS.getString("sTypeIDxx");
                 setMaster("sTypeIDxx", loRS.getString("sTypeIDxx"));
                 setMaster("sTypeDesc", loRS.getString("sTypeDesc"));
             } else {
@@ -641,51 +678,19 @@ public class ClientVehicleInfo {
                 psMessage = "No record found/selected.";
                 return false;
             } else {
+                lsNewVal = (String) loJSON.get("sTypeIDxx");
                 setMaster("sTypeIDxx", (String) loJSON.get("sTypeIDxx"));
                 setMaster("sTypeDesc", (String) loJSON.get("sTypeDesc"));
             }
-        }        
-        return true;
-    }
-    /**
-     * For searching vehicle color when key is pressed.
-     * @param fsValue the search value for the vehicle color.
-     * @return {@code true} if a matching vehicle color is found, {@code false} otherwise.
-    */
-    public boolean searchVehicleColor(String fsValue) throws SQLException{
-        String lsSQL = getSQ_SearchVhclColor();
+        } 
         
-        lsSQL = (MiscUtil.addCondition(lsSQL, " b.sColorDsc LIKE " + SQLUtil.toSQL(fsValue + "%") +
-                                                  " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx")) +
-                                                  " AND a.sModelIDx = " + SQLUtil.toSQL((String) getMaster("sModelIDx")) +
-                                                  " AND a.sTypeIDxx = " + SQLUtil.toSQL((String) getMaster("sTypeIDxx"))
-                                        )  +      " GROUP BY a.sColorIDx " );
-        
-        ResultSet loRS;
-        if (!pbWithUI) {   
-            lsSQL += " LIMIT 1";
-            loRS = poGRider.executeQuery(lsSQL);
-            
-            if (loRS.next()){
-                setMaster("sColorIDx", loRS.getString("sColorIDx"));
-                setMaster("sColorDsc", loRS.getString("sColorDsc"));
-            } else {
-                psMessage = "No record found.";
-                return false;
-            }
-        } else {
-            loRS = poGRider.executeQuery(lsSQL);
-            
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Color", "sColorDsc");
-            
-            if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
-            } else {
-                setMaster("sColorIDx", (String) loJSON.get("sColorIDx"));
-                setMaster("sColorDsc", (String) loJSON.get("sColorDsc"));
-            }
-        }        
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sVhclIDxx", "");
+            setMaster("sColorIDx", "");
+            setMaster("sColorDsc", "");
+            setMaster("sTransMsn", "");
+            setMaster("nYearModl", "");
+        }     
         return true;
     }
     /**
@@ -695,20 +700,20 @@ public class ClientVehicleInfo {
     */
     public boolean searchVehicleTrnsMn(String fsValue) throws SQLException{
         String lsSQL = getSQ_SearchVhclTrnsMn();
-        
+        String lsOrigVal = getMaster(31).toString();
+        String lsNewVal = "";
         lsSQL = (MiscUtil.addCondition(lsSQL, " a.sTransMsn LIKE " + SQLUtil.toSQL(fsValue + "%") +
                                                   " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx")) +
                                                   " AND a.sModelIDx = " + SQLUtil.toSQL((String) getMaster("sModelIDx")) +
-                                                  " AND a.sTypeIDxx = " + SQLUtil.toSQL((String) getMaster("sTypeIDxx")) +
-                                                  " AND a.sColorIDx = " + SQLUtil.toSQL((String) getMaster("sColorIDx"))
+                                                  " AND a.sTypeIDxx = " + SQLUtil.toSQL((String) getMaster("sTypeIDxx")) 
                                         )  +      " GROUP BY a.sTransMsn " );
-        
         ResultSet loRS;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
             
             if (loRS.next()){
+                lsNewVal = loRS.getString("sTransMsn");
                 setMaster("sTransMsn", loRS.getString("sTransMsn"));
             } else {
                 psMessage = "No record found.";
@@ -723,11 +728,69 @@ public class ClientVehicleInfo {
                 psMessage = "No record found/selected.";
                 return false;
             } else {
+                lsNewVal = (String) loJSON.get("sTransMsn");
                 setMaster("sTransMsn", (String) loJSON.get("sTransMsn"));
             }
-        }        
+        }  
+        
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sVhclIDxx", "");
+            setMaster("sColorIDx", "");
+            setMaster("sColorDsc", "");
+            setMaster("nYearModl", "");
+        }      
         return true;
     }
+    /**
+     * For searching vehicle color when key is pressed.
+     * @param fsValue the search value for the vehicle color.
+     * @return {@code true} if a matching vehicle color is found, {@code false} otherwise.
+    */
+    public boolean searchVehicleColor(String fsValue) throws SQLException{
+        String lsSQL = getSQ_SearchVhclColor();
+        String lsOrigVal = getMaster(29).toString();
+        String lsNewVal = "";
+        lsSQL = (MiscUtil.addCondition(lsSQL, " b.sColorDsc LIKE " + SQLUtil.toSQL(fsValue + "%") +
+                                                  " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx")) +
+                                                  " AND a.sModelIDx = " + SQLUtil.toSQL((String) getMaster("sModelIDx")) +
+                                                  " AND a.sTypeIDxx = " + SQLUtil.toSQL((String) getMaster("sTypeIDxx")) +
+                                                  " AND a.sTransMsn = " + SQLUtil.toSQL((String) getMaster("sTransMsn"))
+                                        )  +      " GROUP BY a.sColorIDx " );
+        
+        ResultSet loRS;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            
+            if (loRS.next()){
+                lsNewVal = loRS.getString("sColorIDx");
+                setMaster("sColorIDx", loRS.getString("sColorIDx"));
+                setMaster("sColorDsc", loRS.getString("sColorDsc"));
+            } else {
+                psMessage = "No record found.";
+                return false;
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Color", "sColorDsc");
+            
+            if (loJSON == null){
+                psMessage = "No record found/selected.";
+                return false;
+            } else {
+                lsNewVal = (String) loJSON.get("sColorIDx");
+                setMaster("sColorIDx", (String) loJSON.get("sColorIDx"));
+                setMaster("sColorDsc", (String) loJSON.get("sColorDsc"));
+            }
+        }
+        
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sVhclIDxx", "");
+            setMaster("nYearModl", "");
+        }
+        return true;
+    }
+    
     /**
      * For searching vehicle year model when key is pressed.
      * @param fsValue the search value for the vehicle year model.
@@ -751,6 +814,8 @@ public class ClientVehicleInfo {
             
             if (loRS.next()){
                 setMaster("nYearModl", loRS.getString("nYearModl"));
+                setMaster("sVhclIDxx", loRS.getString("sVhclIDxx"));
+                
             } else {
                 psMessage = "No record found.";
                 return false;
@@ -765,6 +830,7 @@ public class ClientVehicleInfo {
                 return false;
             } else {
                 setMaster("nYearModl", (String) loJSON.get("nYearModl"));
+                setMaster("sVhclIDxx", (String) loJSON.get("sVhclIDxx"));
             }
         }        
         return true;
@@ -773,6 +839,7 @@ public class ClientVehicleInfo {
     /**
      * For searching dealership when key is pressed.
      * @param fsValue the search value for the dealership.
+     * @param fbValue identifier if the user pressed key then it is true and false if it is called thru saving.
      * @return {@code true} if a matching dealership is found, {@code false} otherwise.
     */
     public boolean searchDealer(String fsValue) throws SQLException{

--- a/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
+++ b/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
@@ -525,7 +525,6 @@ public class ClientVehicleInfo {
         String lsSQL = getSQ_Master();
         
         lsSQL = MiscUtil.addCondition(lsSQL, " a.cSoldStat = '1' AND (ISNULL(a.sClientID) OR  TRIM(a.sClientID) = '' )" );
-        
         System.out.println(lsSQL);
         ResultSet loRS;
         loRS = poGRider.executeQuery(lsSQL);
@@ -564,6 +563,7 @@ public class ClientVehicleInfo {
                                                   " GROUP BY a.sMakeIDxx " );
         
         ResultSet loRS;
+        JSONObject loJSON = null;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
@@ -572,18 +572,12 @@ public class ClientVehicleInfo {
                 lsNewVal = loRS.getString("sMakeIDxx");
                 setMaster("sMakeIDxx", loRS.getString("sMakeIDxx"));
                 setMaster("sMakeDesc", loRS.getString("sMakeDesc"));
-            } else {
-                psMessage = "No record found.";
-                return false;
             }
         } else {
             loRS = poGRider.executeQuery(lsSQL);
-            
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Make", "sMakeDesc");
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Make", "sMakeDesc");
             
             if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
             } else {
                 lsNewVal = (String) loJSON.get("sMakeIDxx");
                 setMaster("sMakeIDxx", (String) loJSON.get("sMakeIDxx"));
@@ -601,6 +595,23 @@ public class ClientVehicleInfo {
             setMaster("sColorDsc", "");
             setMaster("sTransMsn", "");
             setMaster("nYearModl", "");
+            setMaster("sFrameNox", "");
+            setMaster("sEngineNo", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            }
+            
         }     
         return true;
     }
@@ -616,8 +627,8 @@ public class ClientVehicleInfo {
         lsSQL = (MiscUtil.addCondition(lsSQL, " b.sModelDsc LIKE " + SQLUtil.toSQL(fsValue + "%") +
                                                   " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx"))
                                         )  +      " GROUP BY a.sModelIDx " );
-        
         ResultSet loRS;
+        JSONObject loJSON = null;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
@@ -626,18 +637,11 @@ public class ClientVehicleInfo {
                 lsNewVal = loRS.getString("sModelIDx");
                 setMaster("sModelIDx", loRS.getString("sModelIDx"));
                 setMaster("sModelDsc", loRS.getString("sModelDsc"));
-            } else {
-                psMessage = "No record found.";
-                return false;
             }
         } else {
             loRS = poGRider.executeQuery(lsSQL);
-            
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Model", "sModelDsc");
-            
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Model", "sModelDsc");
             if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
             } else {
                 lsNewVal = (String) loJSON.get("sModelIDx");
                 setMaster("sModelIDx", (String) loJSON.get("sModelIDx"));
@@ -653,6 +657,23 @@ public class ClientVehicleInfo {
             setMaster("sColorDsc", "");
             setMaster("sTransMsn", "");
             setMaster("nYearModl", "");
+            setMaster("sFrameNox", "");
+            setMaster("sEngineNo", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sModelIDx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sModelIDx","");
+                    return false;
+                }
+            }
+            
         }       
         return true;
     }
@@ -671,6 +692,7 @@ public class ClientVehicleInfo {
                                         )  +      " GROUP BY a.sTypeIDxx " );
         
         ResultSet loRS;
+        JSONObject loJSON = null;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
@@ -679,18 +701,12 @@ public class ClientVehicleInfo {
                 lsNewVal = loRS.getString("sTypeIDxx");
                 setMaster("sTypeIDxx", loRS.getString("sTypeIDxx"));
                 setMaster("sTypeDesc", loRS.getString("sTypeDesc"));
-            } else {
-                psMessage = "No record found.";
-                return false;
             }
         } else {
             loRS = poGRider.executeQuery(lsSQL);
-            
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Type", "sTypeDesc");
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Type", "sTypeDesc");
             
             if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
             } else {
                 lsNewVal = (String) loJSON.get("sTypeIDxx");
                 setMaster("sTypeIDxx", (String) loJSON.get("sTypeIDxx"));
@@ -704,6 +720,20 @@ public class ClientVehicleInfo {
             setMaster("sColorDsc", "");
             setMaster("sTransMsn", "");
             setMaster("nYearModl", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sTypeIDxx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sTypeIDxx","");
+                    return false;
+                }
+            }
         }     
         return true;
     }
@@ -722,6 +752,7 @@ public class ClientVehicleInfo {
                                                   " AND a.sTypeIDxx = " + SQLUtil.toSQL((String) getMaster("sTypeIDxx")) 
                                         )  +      " GROUP BY a.sTransMsn " );
         ResultSet loRS;
+        JSONObject loJSON = null;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
@@ -729,18 +760,12 @@ public class ClientVehicleInfo {
             if (loRS.next()){
                 lsNewVal = loRS.getString("sTransMsn");
                 setMaster("sTransMsn", loRS.getString("sTransMsn"));
-            } else {
-                psMessage = "No record found.";
-                return false;
             }
         } else {
             loRS = poGRider.executeQuery(lsSQL);
-            
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Transmission", "sTransMsn");
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Transmission", "sTransMsn");
             
             if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
             } else {
                 lsNewVal = (String) loJSON.get("sTransMsn");
                 setMaster("sTransMsn", (String) loJSON.get("sTransMsn"));
@@ -752,6 +777,21 @@ public class ClientVehicleInfo {
             setMaster("sColorIDx", "");
             setMaster("sColorDsc", "");
             setMaster("nYearModl", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sTransMsn","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sTransMsn","");
+                    return false;
+                }
+            }
+            
         }      
         return true;
     }
@@ -772,6 +812,7 @@ public class ClientVehicleInfo {
                                         )  +      " GROUP BY a.sColorIDx " );
         
         ResultSet loRS;
+        JSONObject loJSON = null;
         if (!pbWithUI) {   
             lsSQL += " LIMIT 1";
             loRS = poGRider.executeQuery(lsSQL);
@@ -780,17 +821,12 @@ public class ClientVehicleInfo {
                 lsNewVal = loRS.getString("sColorIDx");
                 setMaster("sColorIDx", loRS.getString("sColorIDx"));
                 setMaster("sColorDsc", loRS.getString("sColorDsc"));
-            } else {
-                psMessage = "No record found.";
-                return false;
             }
         } else {
             loRS = poGRider.executeQuery(lsSQL);
-            JSONObject loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Color", "sColorDsc");
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Color", "sColorDsc");
             
             if (loJSON == null){
-                psMessage = "No record found/selected.";
-                return false;
             } else {
                 lsNewVal = (String) loJSON.get("sColorIDx");
                 setMaster("sColorIDx", (String) loJSON.get("sColorIDx"));
@@ -801,6 +837,20 @@ public class ClientVehicleInfo {
         if(!lsNewVal.equals(lsOrigVal)){
             setMaster("sVhclIDxx", "");
             setMaster("nYearModl", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sColorIDx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sColorIDx","");
+                    return false;
+                }
+            }
         }
         return true;
     }

--- a/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
+++ b/src/org/rmj/auto/clients/base/ClientVehicleInfo.java
@@ -394,9 +394,6 @@ public class ClientVehicleInfo {
                         return false;
                     }
             }
-
-             
-              
             
             if (!pbWithParent) poGRider.commitTrans();
             

--- a/src/org/rmj/auto/parameters/VehicleEngineFrame.java
+++ b/src/org/rmj/auto/parameters/VehicleEngineFrame.java
@@ -181,23 +181,30 @@ public class VehicleEngineFrame {
     */
     public boolean searchVhclEngineFrame() throws SQLException{
         String lsSQL = getSQ_Master();
-        
+        System.out.println(lsSQL);
         ResultSet loRS;
         loRS = poGRider.executeQuery(lsSQL);
         JSONObject loJSON = showFXDialog.jsonSearch(poGRider
                                                     , lsSQL
                                                     , ""
-                                                    , "Make»Model»Engine / Frame Pattern"
-                                                    , "sMakeDesc»sModelDsc»sPattern"
-                                                    , "sMakeDesc»sModelDsc»sPattern"
+                                                    //, "Engine / Frame Pattern»Length»Make»Model"
+//                                                    , "Pattern»Length»Make»Model"
+                                                    , "Make»Model»Type»Pattern»Length"
+                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
+                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
+//                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
+//                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
+                                                    //, "sMakeDesc»sModelDsc»sPatternx"
                                                     , 0);
         
         if (loJSON == null){
             psMessage = "No record found/selected.";
             return false;
         } else {
-            if (OpenRecord((String) loJSON.get("sPattern"),Integer.parseInt((String) loJSON.get("sCodeType"))) ){
-                
+            if (OpenRecord((String) loJSON.get("sPatternx"),Integer.parseInt((String) loJSON.get("nCodeType"))) ){
+            }else {
+                psMessage = "No record found/selected.";
+                return false;
             }
         }
                
@@ -205,10 +212,6 @@ public class VehicleEngineFrame {
     }
     
     public boolean OpenRecord(String fsValue, int fnValue){
-        if (poVehicle == null){
-            psMessage = "Application driver is not set.";
-            return false;
-        }
         try {
             pnCodeType = fnValue;
             String lsSQL = "";
@@ -248,10 +251,10 @@ public class VehicleEngineFrame {
         return true;
     }    
     
-    public boolean UpdateRecord(){
-        pnEditMode = EditMode.UPDATE;
-        return true;        
-    }
+//    public boolean UpdateRecord(){
+//        pnEditMode = EditMode.UPDATE;
+//        return true;        
+//    }
     
     public boolean SaveRecord(){
         if (!(pnEditMode == EditMode.ADDNEW || pnEditMode == EditMode.UPDATE)){
@@ -285,51 +288,51 @@ public class VehicleEngineFrame {
                 
                 switch(pnCodeType){
                     case 0:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MAKEFRAME_TABLE, "nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MAKEFRAME_TABLE, "nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType");
                     break;
                     case 1:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELFRAME_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELFRAME_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType");
                     break;
                     case 2:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELENGINE_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELENGINE_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType");
                     break;
                     default:
                     psMessage = "Invalid Code Type.";
                     return false;
                 }
                 
-            } else { //update         
-//                poVehicle.updateString("sModified", poGRider.getUserID());
-//                poVehicle.updateObject("dModified", (Date) poGRider.getServerDate());
-//                poVehicle.updateRow();
-                
-                switch(pnCodeType){
-                    case 0:
-                        MASTER_TABLE = MAKEFRAME_TABLE;
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-                                                    ,MAKEFRAME_TABLE
-                                                    ,"nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc"
-                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
-                    break;
-                    case 1:
-                        MASTER_TABLE = MODELFRAME_TABLE;
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-                                                    ,MODELFRAME_TABLE
-                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc"
-                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
-                    break;
-                    case 2:
-                        MASTER_TABLE = MODELENGINE_TABLE;
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-                                                    ,MODELENGINE_TABLE
-                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc"
-                                                    , "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
-                    break;
-                    default:
-                    psMessage = "Invalid Code Type.";
-                    return false;
-                }
-            
+//            } else { //update         
+////                poVehicle.updateString("sModified", poGRider.getUserID());
+////                poVehicle.updateObject("dModified", (Date) poGRider.getServerDate());
+////                poVehicle.updateRow();
+//                
+//                switch(pnCodeType){
+//                    case 0:
+//                        MASTER_TABLE = MAKEFRAME_TABLE;
+//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+//                                                    ,MAKEFRAME_TABLE
+//                                                    ,"nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType"
+//                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+//                    break;
+//                    case 1:
+//                        MASTER_TABLE = MODELFRAME_TABLE;
+//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+//                                                    ,MODELFRAME_TABLE
+//                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
+//                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+//                    break;
+//                    case 2:
+//                        MASTER_TABLE = MODELENGINE_TABLE;
+//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+//                                                    ,MODELENGINE_TABLE
+//                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
+//                                                    , "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
+//                    break;
+//                    default:
+//                    psMessage = "Invalid Code Type.";
+//                    return false;
+//                }
+//            
             }
             
             if (lsSQL.isEmpty()){
@@ -358,44 +361,47 @@ public class VehicleEngineFrame {
     private String getSQ_Master(){
         return  " SELECT " +
                 "  a.nEntryNox " + 
-                " , IFNULL(a.sFrmePtrn, '') sPatternx " + 
+                " , IFNULL(a.sFrmePtrn, '') AS sPatternx " + 
                 " , '' AS nLengthxx " + 
                 " , a.sEntryByx " + 
                 " , a.dEntryDte " + 
-                " , IFNULL(a.sMakeIDxx, '') sMakeIDxx " + 
-                " , IFNULL(b.sMakeDesc, '') sMakeDesc " + 
+                " , IFNULL(a.sMakeIDxx, '') AS sMakeIDxx " + 
+                " , IFNULL(b.sMakeDesc, '') AS sMakeDesc " + 
                 " , '' AS sModelIDx " + 
                 " , '' AS sModelDsc " +
                 " , 0 AS nCodeType " + 
+                " , 'MANUFACTURING' AS sCodeType " + 
                 " FROM vehicle_make_frame_pattern a " +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx " +
                 " UNION " +
                 " SELECT " + 
                 " a.nEntryNox " + 
-                " , IFNULL(a.sFrmePtrn, '') sPattern " + 
+                " , IFNULL(a.sFrmePtrn, '') AS sPatternx " + 
                 " , nFrmeLenx nLengthxx " +
                 " , a.sEntryByx " + 
                 " , a.dEntryDte " + 
-                " , IFNULL(c.sMakeIDxx, '') sMakeIDxx " + 
-                " , IFNULL(c.sMakeDesc, '') sMakeDesc " + 
+                " , IFNULL(c.sMakeIDxx, '') AS sMakeIDxx " + 
+                " , IFNULL(c.sMakeDesc, '') AS sMakeDesc " + 
                 " , IFNULL(b.sModelIDx, '') AS sModelIDx " + 
                 " , IFNULL(b.sModelDsc, '') AS sModelDsc " + 
                 " , 1 AS nCodeType " + 
+                " , 'FRAME' AS sCodeType " +
                 " FROM vehicle_model_frame_pattern a " +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " + 
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx " + 
                 " UNION " +
                 " SELECT " + 
                 " a.nEntryNox " + 
-                " , IFNULL(a.sEngnPtrn, '') sPattern " + 
+                " , IFNULL(a.sEngnPtrn, '') AS sPatternx " + 
                 " , nEngnLenx nLengthxx " +
                 " , a.sEntryByx " + 
                 " , a.dEntryDte " + 
-                " , IFNULL(c.sMakeIDxx, '') sMakeIDxx " + 
-                " , IFNULL(c.sMakeDesc, '') sMakeDesc " + 
+                " , IFNULL(c.sMakeIDxx, '') AS sMakeIDxx " + 
+                " , IFNULL(c.sMakeDesc, '') AS sMakeDesc " + 
                 " , IFNULL(b.sModelIDx, '') AS sModelIDx " + 
                 " , IFNULL(b.sModelDsc, '') AS sModelDsc " + 
                 " , 2 AS nCodeType " + 
+                " , 'ENGINE' AS sCodeType " +
                 " FROM vehicle_model_engine_pattern a " +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " + 
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx " ;
@@ -405,13 +411,14 @@ public class VehicleEngineFrame {
         return  " SELECT " +
                 "  a.nEntryNox " +
                 " , IFNULL(a.sFrmePtrn, '') sFrmePtrn " +
-                " , '' AS nFrmeLenx " +
+                " , 0 AS nFrmeLenx " +
                 " , a.sEntryByx " +
                 " , a.dEntryDte " +
                 " , IFNULL(a.sMakeIDxx, '') sMakeIDxx " +
                 " , IFNULL(b.sMakeDesc, '') sMakeDesc " +
                 " , '' as sModelIDx " +
                 " , '' as sModelDsc " +
+                " , 0 as nCodeType " +
                 " FROM vehicle_make_frame_pattern a" +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx";
     }
@@ -427,6 +434,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') sMakeDesc " +
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
+                " , 1 as nCodeType " +
                 " FROM vehicle_model_frame_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;
@@ -443,6 +451,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') sMakeDesc " +
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
+                " , 2 as nCodeType " +
                 " FROM vehicle_model_engine_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;
@@ -515,7 +524,6 @@ public class VehicleEngineFrame {
                 }
             break;
         }
-        
         return true;
     }
     

--- a/src/org/rmj/auto/parameters/VehicleEngineFrame.java
+++ b/src/org/rmj/auto/parameters/VehicleEngineFrame.java
@@ -192,27 +192,27 @@ public class VehicleEngineFrame {
                 lsSQL = getSQ_MakeFrame();
 //                sHeader = "Type»Make»Pattern";
 //                sColName = "sCodeType»sMakeDesc»sFrmePtrn";
-                sHeader = "Make»Pattern";
-                sColName = "sMakeDesc»sFrmePtrn";
-                sColCri = "sMakeDesc»sFrmePtrn";
+                sHeader = "Make»Pattern»Code Type";
+                sColName = "sMakeDesc»sFrmePtrn»sCodeType";
+                sColCri = "b.sMakeDesc»a.sFrmePtrn»@sCodeType";
                 sPattern = "sFrmePtrn";
                 break;
             case 1:
                 lsSQL = getSQ_ModelFrame();
 //                sHeader = "Type»Make»Model»Pattern»Length";
 //                sColName = "sCodeType»sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
-                sHeader = "Make»Model»Pattern»Length";
-                sColName = "sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
-                sColCri = "sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
+                sHeader = "Make»Model»Pattern»Length»Code Type";
+                sColName = "sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx»sCodeType";
+                sColCri = "c.sMakeDesc»b.sModelDsc»a.sFrmePtrn»a.nFrmeLenx»@sCodeType";
                 sPattern = "sFrmePtrn";
                 break;
             case 2:
                 lsSQL = getSQ_ModelEngine();
 //                sHeader = "Type»Make»Model»Pattern»Length";
 //                sColName = "sCodeType»sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
-                sHeader = "Make»Model»Pattern»Length";
-                sColName = "sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
-                sColCri = "sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
+                sHeader = "Make»Model»Pattern»Length»Code Type";
+                sColName = "sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx»sCodeType";
+                sColCri = "c.sMakeDesc»b.sModelDsc»a.sEngnPtrn»a.nEngnLenx»@sCodeType";
                 sPattern = "sEngnPtrn";
                 break;
         
@@ -320,10 +320,10 @@ public class VehicleEngineFrame {
         return true;
     }    
     
-//    public boolean UpdateRecord(){
-//        pnEditMode = EditMode.UPDATE;
-//        return true;        
-//    }
+    public boolean UpdateRecord(){
+        pnEditMode = EditMode.UPDATE;
+        return true;        
+    }
     
     public boolean SaveRecord(){
         if (!(pnEditMode == EditMode.ADDNEW || pnEditMode == EditMode.UPDATE)){
@@ -357,51 +357,51 @@ public class VehicleEngineFrame {
                 
                 switch(pnCodeType){
                     case 0:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MAKEFRAME_TABLE, "nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MAKEFRAME_TABLE, "nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType»sCodeType");
                     break;
                     case 1:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELFRAME_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELFRAME_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType»sCodeType");
                     break;
                     case 2:
-                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELENGINE_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType");
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle, MODELENGINE_TABLE, "sMakeIDxx»sMakeDesc»sModelDsc»nCodeType»sCodeType");
                     break;
                     default:
                     psMessage = "Invalid Code Type.";
                     return false;
                 }
                 
-//            } else { //update         
-////                poVehicle.updateString("sModified", poGRider.getUserID());
-////                poVehicle.updateObject("dModified", (Date) poGRider.getServerDate());
-////                poVehicle.updateRow();
-//                
-//                switch(pnCodeType){
-//                    case 0:
-//                        MASTER_TABLE = MAKEFRAME_TABLE;
-//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-//                                                    ,MAKEFRAME_TABLE
-//                                                    ,"nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType"
-//                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
-//                    break;
-//                    case 1:
-//                        MASTER_TABLE = MODELFRAME_TABLE;
-//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-//                                                    ,MODELFRAME_TABLE
-//                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
-//                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
-//                    break;
-//                    case 2:
-//                        MASTER_TABLE = MODELENGINE_TABLE;
-//                        lsSQL = MiscUtil.rowset2SQL(poVehicle
-//                                                    ,MODELENGINE_TABLE
-//                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
-//                                                    , "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
-//                    break;
-//                    default:
-//                    psMessage = "Invalid Code Type.";
-//                    return false;
-//                }
-//            
+            } else { //update         
+                poVehicle.updateString("sModified", poGRider.getUserID());
+                poVehicle.updateObject("dModified", (Date) poGRider.getServerDate());
+                poVehicle.updateRow();
+                
+                switch(pnCodeType){
+                    case 0:
+                        MASTER_TABLE = MAKEFRAME_TABLE;
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+                                                    ,MAKEFRAME_TABLE
+                                                    ,"nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType"
+                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+                    break;
+                    case 1:
+                        MASTER_TABLE = MODELFRAME_TABLE;
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+                                                    ,MODELFRAME_TABLE
+                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
+                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+                    break;
+                    case 2:
+                        MASTER_TABLE = MODELENGINE_TABLE;
+                        lsSQL = MiscUtil.rowset2SQL(poVehicle
+                                                    ,MODELENGINE_TABLE
+                                                    ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
+                                                    , "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
+                    break;
+                    default:
+                    psMessage = "Invalid Code Type.";
+                    return false;
+                }
+            
             }
             
             if (lsSQL.isEmpty()){
@@ -488,7 +488,7 @@ public class VehicleEngineFrame {
                 " , '' as sModelIDx " +
                 " , '' as sModelDsc " +
                 " , 0 as nCodeType " +
-                " , 'MANUFACTURING' as sCodeType " +
+                " , 'MANUFACTURING' sCodeType " +
                 " FROM vehicle_make_frame_pattern a" +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx";
     }

--- a/src/org/rmj/auto/parameters/VehicleEngineFrame.java
+++ b/src/org/rmj/auto/parameters/VehicleEngineFrame.java
@@ -9,6 +9,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.sql.rowset.CachedRowSet;
 import javax.sql.rowset.RowSetFactory;
 import javax.sql.rowset.RowSetProvider;
@@ -42,6 +44,7 @@ public class VehicleEngineFrame {
     private String psMessage;
     
     private CachedRowSet poVehicle;
+    private CachedRowSet poOriginalVehicle;
     
     private int pnCodeType;
     
@@ -154,6 +157,7 @@ public class VehicleEngineFrame {
             ResultSet loRS = poGRider.executeQuery(lsSQL);
             
             RowSetFactory factory = RowSetProvider.newFactory();
+            
             poVehicle = factory.createCachedRowSet();
             poVehicle.populate(loRS);
             MiscUtil.close(loRS);
@@ -161,7 +165,8 @@ public class VehicleEngineFrame {
             poVehicle.last();
             poVehicle.moveToInsertRow();
             
-            MiscUtil.initRowSet(poVehicle); 
+            MiscUtil.initRowSet(poVehicle);
+            poVehicle.updateString("nCodeType", String.valueOf(pnCodeType));
             
             poVehicle.insertRow();
             poVehicle.moveToCurrentRow();                        
@@ -243,43 +248,6 @@ public class VehicleEngineFrame {
         return true;
     }
     
-    /**
-     * For searching vehicle engine frame.
-     * @return {@code true} if a matching available vehicle engine frame is found, {@code false} otherwise.
-    */
-//    public boolean searchVhclEngineFrame() throws SQLException{
-//        String lsSQL = getSQ_Master();
-//        System.out.println(lsSQL);
-//        ResultSet loRS;
-//        loRS = poGRider.executeQuery(lsSQL);
-//        JSONObject loJSON = showFXDialog.jsonSearch(poGRider
-//                                                    , lsSQL
-//                                                    , ""
-//                                                    //, "Engine / Frame Pattern»Length»Make»Model"
-////                                                    , "Pattern»Length»Make»Model"
-//                                                    , "Make»Model»Type»Pattern»Length"
-//                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
-//                                                    , "sMakeDesc»sModelDsc"
-////                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
-////                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
-//                                                    //, "sMakeDesc»sModelDsc»sPatternx"
-//                                                    , 0);
-//        
-//       
-//        if (loJSON == null){
-//            psMessage = "No record found/selected.";
-//            return false;
-//        } else {
-//            if (OpenRecord((String) loJSON.get("sPatternx"),Integer.parseInt((String) loJSON.get("nCodeType"))) ){
-//            }else {
-//                psMessage = "No record found/selected.";
-//                return false;
-//            }
-//        }
-//               
-//        return true;
-//    }
-    
     public boolean OpenRecord(String fsValue, int fnValue){
         try {
             pnCodeType = fnValue;
@@ -321,6 +289,13 @@ public class VehicleEngineFrame {
     }    
     
     public boolean UpdateRecord(){
+        try {
+            if (poVehicle != null){
+                poOriginalVehicle = (CachedRowSet) poVehicle.createCopy();
+            }
+        } catch (SQLException ex) {
+            Logger.getLogger(VehicleEngineFrame.class.getName()).log(Level.SEVERE, null, ex);
+        }
         pnEditMode = EditMode.UPDATE;
         return true;        
     }
@@ -381,21 +356,24 @@ public class VehicleEngineFrame {
                         lsSQL = MiscUtil.rowset2SQL(poVehicle
                                                     ,MAKEFRAME_TABLE
                                                     ,"nFrmeLenx»sMakeDesc»sModelIDx»sModelDsc»nCodeType"
-                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+                                                    , "sFrmePtrn = " + SQLUtil.toSQL(poOriginalVehicle.getString("sFrmePtrn")));
+                                                    //, "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
                     break;
                     case 1:
                         MASTER_TABLE = MODELFRAME_TABLE;
                         lsSQL = MiscUtil.rowset2SQL(poVehicle
                                                     ,MODELFRAME_TABLE
                                                     ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
-                                                    , "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
+                                                    , "sFrmePtrn = " + SQLUtil.toSQL(poOriginalVehicle.getString("sFrmePtrn")));
+                                                    //, "sFrmePtrn = " + SQLUtil.toSQL((String) getMaster("sFrmePtrn")));
                     break;
                     case 2:
                         MASTER_TABLE = MODELENGINE_TABLE;
                         lsSQL = MiscUtil.rowset2SQL(poVehicle
                                                     ,MODELENGINE_TABLE
                                                     ,"sMakeIDxx»sMakeDesc»sModelDsc»nCodeType"
-                                                    , "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
+                                                    , "sEngnPtrn = " + SQLUtil.toSQL(poOriginalVehicle.getString("sEngnPtrn")));
+                                                    //, "sEngnPtrn = " + SQLUtil.toSQL((String) getMaster("sEngnPtrn")));
                     break;
                     default:
                     psMessage = "Invalid Code Type.";
@@ -417,7 +395,8 @@ public class VehicleEngineFrame {
                 return false;
             }
             if (!pbWithParent) poGRider.commitTrans();
-            
+            // Update the original state of the table
+            poOriginalVehicle = (CachedRowSet) poVehicle.createCopy();
         } catch (SQLException e) {
             psMessage = e.getMessage();
             return false;
@@ -438,7 +417,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(b.sMakeDesc, '') AS sMakeDesc " + 
                 " , '' AS sModelIDx " + 
                 " , '' AS sModelDsc " +
-                " , 0 AS nCodeType " + 
+                " , '0' AS nCodeType " + 
                 " , 'MANUFACTURING' AS sCodeType " + 
                 " FROM vehicle_make_frame_pattern a " +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx " +
@@ -453,7 +432,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') AS sMakeDesc " + 
                 " , IFNULL(b.sModelIDx, '') AS sModelIDx " + 
                 " , IFNULL(b.sModelDsc, '') AS sModelDsc " + 
-                " , 1 AS nCodeType " + 
+                " , '1' AS nCodeType " + 
                 " , 'FRAME' AS sCodeType " +
                 " FROM vehicle_model_frame_pattern a " +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " + 
@@ -469,7 +448,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') AS sMakeDesc " + 
                 " , IFNULL(b.sModelIDx, '') AS sModelIDx " + 
                 " , IFNULL(b.sModelDsc, '') AS sModelDsc " + 
-                " , 2 AS nCodeType " + 
+                " , '2' AS nCodeType " + 
                 " , 'ENGINE' AS sCodeType " +
                 " FROM vehicle_model_engine_pattern a " +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " + 
@@ -487,8 +466,10 @@ public class VehicleEngineFrame {
                 " , IFNULL(b.sMakeDesc, '') sMakeDesc " +
                 " , '' as sModelIDx " +
                 " , '' as sModelDsc " +
-                " , 0 as nCodeType " +
+                " , '0' as nCodeType " +
                 " , 'MANUFACTURING' sCodeType " +
+                " , a.sModified " +
+                " , a.dModified " +
                 " FROM vehicle_make_frame_pattern a" +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx";
     }
@@ -504,8 +485,10 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') sMakeDesc " +
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
-                " , 1 as nCodeType " +
+                " , '1' as nCodeType " +
                 " , 'FRAME' as sCodeType " +
+                " , a.sModified " +
+                " , a.dModified " +
                 " FROM vehicle_model_frame_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;
@@ -522,17 +505,143 @@ public class VehicleEngineFrame {
                 " , IFNULL(c.sMakeDesc, '') sMakeDesc " +
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
-                " , 2 as nCodeType " +
+                " , '2' as nCodeType " +
                 " , 'ENGINE' as sCodeType " +
+                " , a.sModified " +
+                " , a.dModified " +
                 " FROM vehicle_model_engine_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;
+    }
+    
+    private String getSQ_SearchVhclMake(){
+        return  " SELECT " +  
+                " IFNULL(a.sMakeIDxx,'') sMakeIDxx  " +   
+                " , IFNULL(b.sMakeDesc,'') sMakeDesc " +   
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +   
+                " FROM vehicle_master a " + 
+                " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx " ;
+    }
+    
+    private String getSQ_SearchVhclModel(){
+        return  " SELECT " +  
+                " IFNULL(a.sModelIDx,'') sModelIDx  " +   
+                " , IFNULL(b.sModelDsc,'') sModelDsc " +  
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +    
+                " FROM vehicle_master a " + 
+                " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx " ;
+    }
+    
+    /**
+     * For searching vehicle make when key is pressed.
+     * @param fsValue the search value for the vehicle make.
+     * @return {@code true} if a matching vehicle make is found, {@code false} otherwise.
+    */
+    public boolean searchVehicleMake(String fsValue) throws SQLException{
+        String lsSQL = getSQ_SearchVhclMake();
+        String lsOrigVal = getMaster(6).toString();
+        String lsNewVal = "";
+        lsSQL = (MiscUtil.addCondition(lsSQL, " b.sMakeDesc LIKE " + SQLUtil.toSQL(fsValue + "%"))  +
+                                                  " GROUP BY a.sMakeIDxx " );
+        
+        ResultSet loRS;
+        JSONObject loJSON = null;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            
+            if (loRS.next()){
+                lsNewVal = loRS.getString("sMakeIDxx");
+                setMaster("sMakeIDxx", loRS.getString("sMakeIDxx"));
+                setMaster("sMakeDesc", loRS.getString("sMakeDesc"));
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Make", "sMakeDesc");
+            
+            if (loJSON == null){
+            } else {
+                lsNewVal = (String) loJSON.get("sMakeIDxx");
+                setMaster("sMakeIDxx", (String) loJSON.get("sMakeIDxx"));
+                setMaster("sMakeDesc", (String) loJSON.get("sMakeDesc"));
+            }
+        }   
+            
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sModelIDx", "");
+            setMaster("sModelDsc", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            }
+            
+        }     
+        return true;
+    }
+    /**
+     * For searching vehicle model when key is pressed.
+     * @param fsValue the search value for the vehicle model.
+     * @return {@code true} if a matching vehicle model is found, {@code false} otherwise.
+    */
+    public boolean searchVehicleModel(String fsValue) throws SQLException{
+        String lsSQL = getSQ_SearchVhclModel();
+        String lsOrigVal = getMaster(8).toString();
+        String lsNewVal = "";
+        lsSQL = (MiscUtil.addCondition(lsSQL, " b.sModelDsc LIKE " + SQLUtil.toSQL(fsValue + "%") +
+                                                  " AND a.sMakeIDxx = " + SQLUtil.toSQL((String) getMaster("sMakeIDxx"))
+                                        )  +      " GROUP BY a.sModelIDx " );
+        ResultSet loRS;
+        JSONObject loJSON = null;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            
+            if (loRS.next()){
+                lsNewVal = loRS.getString("sModelIDx");
+                setMaster("sModelIDx", loRS.getString("sModelIDx"));
+                setMaster("sModelDsc", loRS.getString("sModelDsc"));
+            } else {
+                psMessage = "No record found.";
+                setMaster("sModelIDx","");
+                return false;
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Model", "sModelDsc");
+            if (loJSON != null){
+                lsNewVal = (String) loJSON.get("sModelIDx");
+                setMaster("sModelIDx", (String) loJSON.get("sModelIDx"));
+                setMaster("sModelDsc", (String) loJSON.get("sModelDsc"));
+            } else {
+                psMessage = "No record found/selected.";
+                setMaster("sModelIDx","");
+                return false;
+            }
+        } 
+               
+        return true;
     }
     
     private boolean isEntryOK() throws SQLException{
         poVehicle.first();
         String lsSQL = "";
         ResultSet loRS;
+        
+        if (poVehicle.getString("sMakeIDxx").isEmpty()){
+            psMessage = "Make is not set.";
+            return false;
+        }
+
         switch(pnCodeType){
             case 0:
                 if (poVehicle.getString("sFrmePtrn").isEmpty()){
@@ -544,12 +653,25 @@ public class VehicleEngineFrame {
                                                         " AND a.sMakeIDxx = " + SQLUtil.toSQL(poVehicle.getString("sMakeIDxx"))); 
                 loRS = poGRider.executeQuery(lsSQL);
                 if (MiscUtil.RecordCount(loRS) > 0){
-                    psMessage = "Frame Pattern already exists";
-                    MiscUtil.close(loRS);        
-                    return false;
+                    if (pnEditMode == EditMode.ADDNEW){
+                        psMessage = "Frame Pattern already exists";
+                        MiscUtil.close(loRS);        
+                        return false;
+                    } else {
+                        if (!poOriginalVehicle.getString("sFrmePtrn").equals(poVehicle.getString("sFrmePtrn"))){
+                            psMessage = "Frame Pattern already exists";
+                            MiscUtil.close(loRS);        
+                            return false;
+                        }
+                    
+                    }
                 }
             break;
             case 1:
+                if (poVehicle.getString("sModelIDx").isEmpty()){
+                    psMessage = "Model is not set.";
+                    return false;
+                }
                 if (poVehicle.getString("sFrmePtrn").isEmpty()){
                     psMessage = "Frame Pattern is not set.";
                     return false;
@@ -558,21 +680,33 @@ public class VehicleEngineFrame {
                     psMessage = "Frame Length is not set.";
                     return false;
                 }
-                if (poVehicle.getInt("nFrmeLenx") <= 0){
+                if (poVehicle.getInt("nFrmeLenx") < 5){
                     psMessage = "Invalid Frame Length.";
                     return false;
                 }
                 lsSQL = getSQ_ModelFrame();
                 lsSQL = MiscUtil.addCondition(lsSQL," a.sFrmePtrn = " + SQLUtil.toSQL(poVehicle.getString("sFrmePtrn")) +
-                                                        "AND a.sModelIDx = " + SQLUtil.toSQL(poVehicle.getString("sModelIDx"))); 
+                                                        "AND a.sModelIDx = " + SQLUtil.toSQL(poVehicle.getString("sModelIDx")) ); 
                 loRS = poGRider.executeQuery(lsSQL);
                 if (MiscUtil.RecordCount(loRS) > 0){
-                    psMessage = "Frame Pattern already exists";
-                    MiscUtil.close(loRS);        
-                    return false;
-                }
+                    if (pnEditMode == EditMode.ADDNEW){
+                        psMessage = "Frame Pattern already exists";
+                        MiscUtil.close(loRS);        
+                        return false;
+                    }  else {
+                        if (!poOriginalVehicle.getString("sFrmePtrn").equals(poVehicle.getString("sFrmePtrn"))){
+                            psMessage = "Frame Pattern already exists";
+                            MiscUtil.close(loRS);        
+                            return false;
+                        }
+                    }
+                } 
             break;
             case 2:
+                if (poVehicle.getString("sModelIDx").isEmpty()){
+                    psMessage = "Model is not set.";
+                    return false;
+                }
                 if (poVehicle.getString("sEngnPtrn").isEmpty()){
                     psMessage = "Engine Pattern is not set.";
                     return false;
@@ -581,7 +715,7 @@ public class VehicleEngineFrame {
                     psMessage = "Engine Length is not set.";
                     return false;
                 }
-                if (poVehicle.getInt("nEngnLenx") <= 0){
+                if (poVehicle.getInt("nEngnLenx") < 3){
                     psMessage = "Invalid Engine Length.";
                     return false;
                 }
@@ -590,10 +724,18 @@ public class VehicleEngineFrame {
                                                         "AND a.sModelIDx = " + SQLUtil.toSQL(poVehicle.getString("sModelIDx"))); 
                 loRS = poGRider.executeQuery(lsSQL);
                 if (MiscUtil.RecordCount(loRS) > 0){
-                    psMessage = "Engine Pattern already exists";
-                    MiscUtil.close(loRS);        
-                    return false;
-                }
+                    if (pnEditMode == EditMode.ADDNEW){
+                        psMessage = "Engine Pattern already exists";
+                        MiscUtil.close(loRS);        
+                        return false;
+                    } else {
+                        if (!poOriginalVehicle.getString("sEngnPtrn").equals(poVehicle.getString("sEngnPtrn"))){
+                            psMessage = "Frame Pattern already exists";
+                            MiscUtil.close(loRS);        
+                            return false;
+                        }
+                    }
+                }  
             break;
         }
         return true;

--- a/src/org/rmj/auto/parameters/VehicleEngineFrame.java
+++ b/src/org/rmj/auto/parameters/VehicleEngineFrame.java
@@ -179,29 +179,61 @@ public class VehicleEngineFrame {
      * For searching vehicle engine frame.
      * @return {@code true} if a matching available vehicle engine frame is found, {@code false} otherwise.
     */
-    public boolean searchVhclEngineFrame() throws SQLException{
-        String lsSQL = getSQ_Master();
-        System.out.println(lsSQL);
+    public boolean searchVhclEngineFrame(Integer fnValue) throws SQLException{
+        String lsSQL = "";
+        String sHeader = "";
+        String sColName = "";
+        String sColCri = "";
+        String sPattern = "";
+        String sCodeType = "";
+        
+        switch(fnValue) {
+            case 0:
+                lsSQL = getSQ_MakeFrame();
+//                sHeader = "Type»Make»Pattern";
+//                sColName = "sCodeType»sMakeDesc»sFrmePtrn";
+                sHeader = "Make»Pattern";
+                sColName = "sMakeDesc»sFrmePtrn";
+                sColCri = "sMakeDesc»sFrmePtrn";
+                sPattern = "sFrmePtrn";
+                break;
+            case 1:
+                lsSQL = getSQ_ModelFrame();
+//                sHeader = "Type»Make»Model»Pattern»Length";
+//                sColName = "sCodeType»sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
+                sHeader = "Make»Model»Pattern»Length";
+                sColName = "sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
+                sColCri = "sMakeDesc»sModelDsc»sFrmePtrn»nFrmeLenx";
+                sPattern = "sFrmePtrn";
+                break;
+            case 2:
+                lsSQL = getSQ_ModelEngine();
+//                sHeader = "Type»Make»Model»Pattern»Length";
+//                sColName = "sCodeType»sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
+                sHeader = "Make»Model»Pattern»Length";
+                sColName = "sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
+                sColCri = "sMakeDesc»sModelDsc»sEngnPtrn»nEngnLenx";
+                sPattern = "sEngnPtrn";
+                break;
+        
+        }
+        
         ResultSet loRS;
         loRS = poGRider.executeQuery(lsSQL);
         JSONObject loJSON = showFXDialog.jsonSearch(poGRider
                                                     , lsSQL
                                                     , ""
-                                                    //, "Engine / Frame Pattern»Length»Make»Model"
-//                                                    , "Pattern»Length»Make»Model"
-                                                    , "Make»Model»Type»Pattern»Length"
-                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
-                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
-//                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
-//                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
-                                                    //, "sMakeDesc»sModelDsc»sPatternx"
+                                                    , sHeader
+                                                    , sColName
+                                                    , sColCri
                                                     , 0);
         
+       
         if (loJSON == null){
             psMessage = "No record found/selected.";
             return false;
         } else {
-            if (OpenRecord((String) loJSON.get("sPatternx"),Integer.parseInt((String) loJSON.get("nCodeType"))) ){
+            if (OpenRecord((String) loJSON.get(sPattern),fnValue) ){
             }else {
                 psMessage = "No record found/selected.";
                 return false;
@@ -210,6 +242,43 @@ public class VehicleEngineFrame {
                
         return true;
     }
+    
+    /**
+     * For searching vehicle engine frame.
+     * @return {@code true} if a matching available vehicle engine frame is found, {@code false} otherwise.
+    */
+//    public boolean searchVhclEngineFrame() throws SQLException{
+//        String lsSQL = getSQ_Master();
+//        System.out.println(lsSQL);
+//        ResultSet loRS;
+//        loRS = poGRider.executeQuery(lsSQL);
+//        JSONObject loJSON = showFXDialog.jsonSearch(poGRider
+//                                                    , lsSQL
+//                                                    , ""
+//                                                    //, "Engine / Frame Pattern»Length»Make»Model"
+////                                                    , "Pattern»Length»Make»Model"
+//                                                    , "Make»Model»Type»Pattern»Length"
+//                                                    , "sMakeDesc»sModelDsc»sCodeType»sPatternx»nLengthxx"
+//                                                    , "sMakeDesc»sModelDsc"
+////                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
+////                                                    , "sPatternx»nLengthxx»sMakeDesc»sModelDsc"
+//                                                    //, "sMakeDesc»sModelDsc»sPatternx"
+//                                                    , 0);
+//        
+//       
+//        if (loJSON == null){
+//            psMessage = "No record found/selected.";
+//            return false;
+//        } else {
+//            if (OpenRecord((String) loJSON.get("sPatternx"),Integer.parseInt((String) loJSON.get("nCodeType"))) ){
+//            }else {
+//                psMessage = "No record found/selected.";
+//                return false;
+//            }
+//        }
+//               
+//        return true;
+//    }
     
     public boolean OpenRecord(String fsValue, int fnValue){
         try {
@@ -419,6 +488,7 @@ public class VehicleEngineFrame {
                 " , '' as sModelIDx " +
                 " , '' as sModelDsc " +
                 " , 0 as nCodeType " +
+                " , 'MANUFACTURING' as sCodeType " +
                 " FROM vehicle_make_frame_pattern a" +
                 " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx";
     }
@@ -435,6 +505,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
                 " , 1 as nCodeType " +
+                " , 'FRAME' as sCodeType " +
                 " FROM vehicle_model_frame_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;
@@ -452,6 +523,7 @@ public class VehicleEngineFrame {
                 " , IFNULL(a.sModelIDx, '') sModelIDx " +
                 " , IFNULL(b.sModelDsc, '') sModelDsc " +
                 " , 2 as nCodeType " +
+                " , 'ENGINE' as sCodeType " +
                 " FROM vehicle_model_engine_pattern a" +
                 " LEFT JOIN vehicle_model b ON b.sModelIDx = a.sModelIDx" +
                 " LEFT JOIN vehicle_make c ON c.sMakeIDxx = b.sMakeIDxx" ;

--- a/src/org/rmj/auto/parameters/VehicleModel.java
+++ b/src/org/rmj/auto/parameters/VehicleModel.java
@@ -278,7 +278,7 @@ public class VehicleModel {
     private String getSQ_VhclDesc(){
         return "SELECT" +
                     " sVhclIDxx" +   
-                    " IFNULL(sDescript, '') sDescript" +   
+                    ", IFNULL(sDescript, '') sDescript" +   
                 " FROM vehicle_master ";
     }
     
@@ -301,6 +301,7 @@ public class VehicleModel {
         lsSQL = getSQ_Master();
         lsSQL = MiscUtil.addCondition(lsSQL, "a.sModelDsc = " + SQLUtil.toSQL(poVehicle.getString("sModelDsc")) +
                                                 " AND a.sModelIDx <> " + SQLUtil.toSQL(poVehicle.getString("sModelIDx")) ); 
+        System.out.println(lsSQL);
         loRS = poGRider.executeQuery(lsSQL);
         if (MiscUtil.RecordCount(loRS) > 0){
             psMessage = "Existing Vehicle Model Description.";
@@ -311,6 +312,7 @@ public class VehicleModel {
         /*CHECK WHEN VEHICLE MODEL IS ALREADY LINKED TO VEHICLE DESCRIPTION*/
         lsSQL = getSQ_VhclDesc();
         lsSQL = MiscUtil.addCondition(lsSQL, "sModelIDx = " + SQLUtil.toSQL(poVehicle.getString("sModelIDx")) ); 
+        System.out.println(lsSQL);
         loRS = poGRider.executeQuery(lsSQL);
         if (MiscUtil.RecordCount(loRS) > 0){
             psMessage = "Vehicle Model is already used in Vehicle Description. Please contact system administrator to address this issue.";

--- a/src/org/rmj/auto/parameters/VehicleModel.java
+++ b/src/org/rmj/auto/parameters/VehicleModel.java
@@ -12,9 +12,11 @@ import java.util.Date;
 import javax.sql.rowset.CachedRowSet;
 import javax.sql.rowset.RowSetFactory;
 import javax.sql.rowset.RowSetProvider;
+import org.json.simple.JSONObject;
 import org.rmj.appdriver.GRider;
 import org.rmj.appdriver.MiscUtil;
 import org.rmj.appdriver.SQLUtil;
+import org.rmj.appdriver.agentfx.ui.showFXDialog;
 import org.rmj.appdriver.callback.MasterCallback;
 import org.rmj.appdriver.constants.EditMode;
 import org.rmj.appdriver.constants.RecordStatus;
@@ -280,6 +282,71 @@ public class VehicleModel {
                     " sVhclIDxx" +   
                     ", IFNULL(sDescript, '') sDescript" +   
                 " FROM vehicle_master ";
+    }
+    
+    private String getSQ_SearchVhclMake(){
+        return  " SELECT " +  
+                " IFNULL(a.sMakeIDxx,'') sMakeIDxx  " +   
+                " , IFNULL(b.sMakeDesc,'') sMakeDesc " +   
+                " , IFNULL(a.sVhclIDxx,'') sVhclIDxx  " +   
+                " FROM vehicle_master a " + 
+                " LEFT JOIN vehicle_make b ON b.sMakeIDxx = a.sMakeIDxx " ;
+    }
+    
+    /**
+     * For searching vehicle make when key is pressed.
+     * @param fsValue the search value for the vehicle make.
+     * @return {@code true} if a matching vehicle make is found, {@code false} otherwise.
+    */
+    public boolean searchVehicleMake(String fsValue) throws SQLException{
+        String lsSQL = getSQ_SearchVhclMake();
+        String lsOrigVal = getMaster(6).toString();
+        String lsNewVal = "";
+        lsSQL = (MiscUtil.addCondition(lsSQL, " b.sMakeDesc LIKE " + SQLUtil.toSQL(fsValue + "%"))  +
+                                                  " GROUP BY a.sMakeIDxx " );
+        ResultSet loRS;
+        JSONObject loJSON = null;
+        if (!pbWithUI) {   
+            lsSQL += " LIMIT 1";
+            loRS = poGRider.executeQuery(lsSQL);
+            
+            if (loRS.next()){
+                lsNewVal = loRS.getString("sMakeIDxx");
+                setMaster("sMakeIDxx", loRS.getString("sMakeIDxx"));
+                setMaster("sMakeDesc", loRS.getString("sMakeDesc"));
+            }
+        } else {
+            loRS = poGRider.executeQuery(lsSQL);
+            loJSON = showFXDialog.jsonBrowse(poGRider, loRS, "Vehicle Make", "sMakeDesc");
+            
+            if (loJSON == null){
+            } else {
+                lsNewVal = (String) loJSON.get("sMakeIDxx");
+                setMaster("sMakeIDxx", (String) loJSON.get("sMakeIDxx"));
+                setMaster("sMakeDesc", (String) loJSON.get("sMakeDesc"));
+            }
+        }   
+            
+        if(!lsNewVal.equals(lsOrigVal)){
+            setMaster("sModelIDx", "");
+            setMaster("sModelDsc", "");
+            
+            if (!pbWithUI) {
+                if (!loRS.next()){
+                    psMessage = "No record found.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            } else {
+                if (loJSON == null){
+                    psMessage = "No record found/selected.";
+                    setMaster("sMakeIDxx","");
+                    return false;
+                }
+            }
+            
+        }     
+        return true;
     }
     
     private boolean isEntryOK() throws SQLException{

--- a/src/org/rmj/auto/parameters/VehicleType.java
+++ b/src/org/rmj/auto/parameters/VehicleType.java
@@ -326,6 +326,7 @@ public class VehicleType {
                 setMaster("sVhclSize", loRS.getString("sVhclSize"));
             } else {
                 psMessage = "No record found.";
+                setMaster("sVhclSize", "");
                 return false;
             }
         } else {
@@ -335,6 +336,7 @@ public class VehicleType {
             
             if (loJSON == null){
                 psMessage = "No record found/selected.";
+                setMaster("sVhclSize", "");
                 return false;
             } else {
                 setMaster("sVhclSize", (String) loJSON.get("sVhclSize"));
@@ -368,6 +370,8 @@ public class VehicleType {
                 setMaster("sVariantx_b", loRS.getString("sVariantx"));
             } else {
                 psMessage = "No record found.";
+                setMaster("sVariantx_a", "");
+                setMaster("sVariantx_b", "");
                 return false;
             }
         } else {
@@ -377,6 +381,8 @@ public class VehicleType {
             
             if (loJSON == null){
                 psMessage = "No record found/selected.";
+                setMaster("sVariantx_a", "");
+                setMaster("sVariantx_b", "");
                 return false;
             } else {
                 setMaster("sVariantx_a", (String) loJSON.get("sVariantx"));


### PR DESCRIPTION
- Removed setmaster for enterred by and date and modified by and date.
- Added passing parameter of lnCtr for CompareRows
- Added closing parenthesis on query for available vehicle.
- debugged class
- re order set master case for columns
- added validation when user changed selected vehicle description set empty string for the following columns and for vehicle ID
- Added validation on search for dealer name.
- Added search town or province for place of registration.
- Test setting of data. fixed some issues at search and added manufacturing/frame/engine word for filtering data in search.
- Changed method for searching of engine and frame added codetype on searching.
- Fixed sql statement for vehicle description added "," (Comma) : getSQ_VhclDesc() ", IFNULL(sDescript, '') sDescript" +
- Added Code type on display on searching for Manufacturing, Frame and Engine.
- Align header for searching of available vehicles.
- Added Validation for Engine and frame before setting value to class and saving.
- Added Validation for saving of vehicle registration.
- Added reseting value for engine and frame when make and model was changed.
- Realign return false on searching of vehicle make, model, type, transmission, color and year to reset next value when current column value was changed.
- Moved condition for not empty plate no, registered date and place registered at insert of vehicle serial registration.
- Added set to empty string on search of vehicle size, variant a and b when no record found.
- Fix error on validating of engine and frame entry.
- Added validation on edit of Engine and Frame entry.
- Added search for make and model.
- Added search for make.